### PR TITLE
Add automatic SignWriting font loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -227,3 +227,7 @@ Temporary Items
 # Built Visual Studio Code Extensions
 *.vsix
 
+
+.Rapp.history
+.Rhistory
+.RData

--- a/inventories/inv00001.html
+++ b/inventories/inv00001.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ASL (LQ_1)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>ASL (LQ_1)</h1>
@@ -55,8 +81,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00004.html">S203</a></td>
-<td>񆄱</td>
-<td>񆅁</td>
+<td class="signwriting">񆄱</td>
+<td class="signwriting">񆅁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00006.html">S1fb</a></td>
-<td>񅸱</td>
-<td></td>
+<td class="signwriting">񅸱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00025.html">S10c</a></td>
-<td>񀒑</td>
-<td></td>
+<td class="signwriting">񀒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00031.html">S1e1</a></td>
-<td>񅑱</td>
-<td>񅑡</td>
+<td class="signwriting">񅑱</td>
+<td class="signwriting">񅑡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00039.html">S119</a></td>
-<td>񀥱</td>
-<td></td>
+<td class="signwriting">񀥱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00043.html">S118</a></td>
-<td>񀤑</td>
-<td></td>
+<td class="signwriting">񀤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00053.html">S19c</a></td>
-<td>񃪑</td>
-<td></td>
+<td class="signwriting">񃪑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00054.html">S1a0</a></td>
-<td>񃰑</td>
-<td></td>
+<td class="signwriting">񃰑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00058.html">S112</a></td>
-<td>񀛑</td>
-<td></td>
+<td class="signwriting">񀛑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>3_spread</td>
 <td>extended</td>
 <td><a href="../segments/seg00073.html">S1ab</a></td>
-<td>񄀱</td>
-<td></td>
+<td class="signwriting">񄀱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00082.html">S14b</a></td>
-<td>񁰱</td>
-<td></td>
+<td class="signwriting">񁰱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00090.html">S202</a></td>
-<td>񆃑</td>
-<td></td>
+<td class="signwriting">񆃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00094.html">S146</a></td>
-<td>񁩑</td>
-<td></td>
+<td class="signwriting">񁩑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00097.html">S145</a></td>
-<td>񁧱</td>
-<td></td>
+<td class="signwriting">񁧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00101.html">S157</a></td>
-<td>񂂱</td>
-<td></td>
+<td class="signwriting">񂂱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00103.html">S1c5</a></td>
-<td>񄧱</td>
-<td></td>
+<td class="signwriting">񄧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00134.html">S153</a></td>
-<td>񁼱</td>
-<td></td>
+<td class="signwriting">񁼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00139.html">S187</a></td>
-<td>񃊱</td>
-<td></td>
+<td class="signwriting">񃊱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00141.html">S1a4</a></td>
-<td>񃶁</td>
-<td></td>
+<td class="signwriting">񃶁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00144.html">S1bb</a></td>
-<td>񄘱</td>
-<td></td>
+<td class="signwriting">񄘱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -460,8 +486,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -469,8 +495,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00151.html">S18d</a></td>
-<td>񃓱</td>
-<td></td>
+<td class="signwriting">񃓱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -478,8 +504,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00155.html">S1d1</a></td>
-<td>񄹱</td>
-<td></td>
+<td class="signwriting">񄹱</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00002.html
+++ b/inventories/inv00002.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>CSL, ZGS (LQ_2)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>CSL, ZGS (LQ_2)</h1>
@@ -55,8 +81,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00004.html">S203</a></td>
-<td>񆄱</td>
-<td>񆅁</td>
+<td class="signwriting">񆄱</td>
+<td class="signwriting">񆅁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00007.html">S1fc</a></td>
-<td>񅺡</td>
-<td>񅺑</td>
+<td class="signwriting">񅺡</td>
+<td class="signwriting">񅺑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00008.html">S1fd</a></td>
-<td>񅼁</td>
-<td>񅻱</td>
+<td class="signwriting">񅼁</td>
+<td class="signwriting">񅻱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00020.html">S1c6</a></td>
-<td>񄩁</td>
-<td>񄩑</td>
+<td class="signwriting">񄩁</td>
+<td class="signwriting">񄩑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00024.html">S1e0</a></td>
-<td>񅐁</td>
-<td>񅐑</td>
+<td class="signwriting">񅐁</td>
+<td class="signwriting">񅐑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00026.html">S1f2</a></td>
-<td>񅫁</td>
-<td></td>
+<td class="signwriting">񅫁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00030.html">S198</a></td>
-<td>񃤑</td>
-<td></td>
+<td class="signwriting">񃤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00031.html">S1e1</a></td>
-<td>񅑱</td>
-<td>񅑡</td>
+<td class="signwriting">񅑱</td>
+<td class="signwriting">񅑡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00048.html">S11d</a></td>
-<td>񀫡</td>
-<td></td>
+<td class="signwriting">񀫡</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00053.html">S19c</a></td>
-<td>񃪑</td>
-<td></td>
+<td class="signwriting">񃪑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00054.html">S1a0</a></td>
-<td>񃰑</td>
-<td></td>
+<td class="signwriting">񃰑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00083.html">S180</a></td>
-<td>񃀑</td>
-<td>񃀁</td>
+<td class="signwriting">񃀑</td>
+<td class="signwriting">񃀁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00087.html">S16e</a></td>
-<td>񂥑</td>
-<td></td>
+<td class="signwriting">񂥑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00097.html">S145</a></td>
-<td>񁧱</td>
-<td></td>
+<td class="signwriting">񁧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00098.html">S14e</a></td>
-<td>񁵑</td>
-<td></td>
+<td class="signwriting">񁵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00104.html">S199</a></td>
-<td>񃥱</td>
-<td></td>
+<td class="signwriting">񃥱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00108.html">S1ed</a></td>
-<td>񅣡</td>
-<td>񅢑</td>
+<td class="signwriting">񅣡</td>
+<td class="signwriting">񅢑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00113.html">S1f4</a></td>
-<td>񅮁</td>
-<td>񅮑</td>
+<td class="signwriting">񅮁</td>
+<td class="signwriting">񅮑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00115.html">S13d</a></td>
-<td>񁛡</td>
-<td>񁛱</td>
+<td class="signwriting">񁛡</td>
+<td class="signwriting">񁛱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00116.html">S13f</a></td>
-<td>񁞱</td>
-<td></td>
+<td class="signwriting">񁞱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td>2finNonspread_othersFist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00118.html">S1a3</a></td>
-<td>񃴱</td>
-<td></td>
+<td class="signwriting">񃴱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00121.html">S128</a></td>
-<td>񀼑</td>
-<td></td>
+<td class="signwriting">񀼑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -460,8 +486,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -469,8 +495,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00130.html">S17c</a></td>
-<td>񂺑</td>
-<td></td>
+<td class="signwriting">񂺑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -478,8 +504,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00131.html">S17d</a></td>
-<td>񂻱</td>
-<td></td>
+<td class="signwriting">񂻱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -487,8 +513,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -496,8 +522,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00134.html">S153</a></td>
-<td>񁼱</td>
-<td></td>
+<td class="signwriting">񁼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -505,8 +531,8 @@
 <td>4finSpread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00137.html">S155</a></td>
-<td>񁿱</td>
-<td></td>
+<td class="signwriting">񁿱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -514,8 +540,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00139.html">S187</a></td>
-<td>񃊱</td>
-<td></td>
+<td class="signwriting">񃊱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -523,8 +549,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -532,8 +558,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00146.html">S1d0</a></td>
-<td>񄸑</td>
-<td></td>
+<td class="signwriting">񄸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -541,8 +567,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00147.html">S1d5</a></td>
-<td>񄿱</td>
-<td></td>
+<td class="signwriting">񄿱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -550,8 +576,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00150.html">S18c</a></td>
-<td>񃒑</td>
-<td></td>
+<td class="signwriting">񃒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -559,8 +585,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00153.html">S1c1</a></td>
-<td>񄡱</td>
-<td></td>
+<td class="signwriting">񄡱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -568,8 +594,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00154.html">S1c3</a></td>
-<td>񄤱</td>
-<td></td>
+<td class="signwriting">񄤱</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00003.html
+++ b/inventories/inv00003.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>DGS (LQ_3)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>DGS (LQ_3)</h1>
@@ -55,8 +81,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00004.html">S203</a></td>
-<td>񆄱</td>
-<td>񆅁</td>
+<td class="signwriting">񆄱</td>
+<td class="signwriting">񆅁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00031.html">S1e1</a></td>
-<td>񅑱</td>
-<td>񅑡</td>
+<td class="signwriting">񅑱</td>
+<td class="signwriting">񅑡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00061.html">S121</a></td>
-<td>񀱱</td>
-<td></td>
+<td class="signwriting">񀱱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00085.html">S149</a></td>
-<td>񁭱</td>
-<td></td>
+<td class="signwriting">񁭱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00097.html">S145</a></td>
-<td>񁧱</td>
-<td></td>
+<td class="signwriting">񁧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00103.html">S1c5</a></td>
-<td>񄧱</td>
-<td></td>
+<td class="signwriting">񄧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00108.html">S1ed</a></td>
-<td>񅣡</td>
-<td>񅢑</td>
+<td class="signwriting">񅣡</td>
+<td class="signwriting">񅢑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00113.html">S1f4</a></td>
-<td>񅮁</td>
-<td>񅮑</td>
+<td class="signwriting">񅮁</td>
+<td class="signwriting">񅮑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00131.html">S17d</a></td>
-<td>񂻱</td>
-<td></td>
+<td class="signwriting">񂻱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00146.html">S1d0</a></td>
-<td>񄸑</td>
-<td></td>
+<td class="signwriting">񄸑</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00004.html
+++ b/inventories/inv00004.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>HKSL (LQ_4)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>HKSL (LQ_4)</h1>
@@ -55,8 +81,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00004.html">S203</a></td>
-<td>񆄱</td>
-<td>񆅁</td>
+<td class="signwriting">񆄱</td>
+<td class="signwriting">񆅁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00006.html">S1fb</a></td>
-<td>񅸱</td>
-<td></td>
+<td class="signwriting">񅸱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00007.html">S1fc</a></td>
-<td>񅺡</td>
-<td>񅺑</td>
+<td class="signwriting">񅺡</td>
+<td class="signwriting">񅺑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00008.html">S1fd</a></td>
-<td>񅼁</td>
-<td>񅻱</td>
+<td class="signwriting">񅼁</td>
+<td class="signwriting">񅻱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00020.html">S1c6</a></td>
-<td>񄩁</td>
-<td>񄩑</td>
+<td class="signwriting">񄩁</td>
+<td class="signwriting">񄩑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00024.html">S1e0</a></td>
-<td>񅐁</td>
-<td>񅐑</td>
+<td class="signwriting">񅐁</td>
+<td class="signwriting">񅐑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00027.html">S1f3</a></td>
-<td>񅬱</td>
-<td></td>
+<td class="signwriting">񅬱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00030.html">S198</a></td>
-<td>񃤑</td>
-<td></td>
+<td class="signwriting">񃤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00031.html">S1e1</a></td>
-<td>񅑱</td>
-<td>񅑡</td>
+<td class="signwriting">񅑱</td>
+<td class="signwriting">񅑡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00053.html">S19c</a></td>
-<td>񃪑</td>
-<td></td>
+<td class="signwriting">񃪑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00054.html">S1a0</a></td>
-<td>񃰑</td>
-<td></td>
+<td class="signwriting">񃰑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00061.html">S121</a></td>
-<td>񀱱</td>
-<td></td>
+<td class="signwriting">񀱱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00090.html">S202</a></td>
-<td>񆃑</td>
-<td></td>
+<td class="signwriting">񆃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00103.html">S1c5</a></td>
-<td>񄧱</td>
-<td></td>
+<td class="signwriting">񄧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00108.html">S1ed</a></td>
-<td>񅣡</td>
-<td>񅢑</td>
+<td class="signwriting">񅣡</td>
+<td class="signwriting">񅢑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00113.html">S1f4</a></td>
-<td>񅮁</td>
-<td>񅮑</td>
+<td class="signwriting">񅮁</td>
+<td class="signwriting">񅮑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00115.html">S13d</a></td>
-<td>񁛡</td>
-<td>񁛱</td>
+<td class="signwriting">񁛡</td>
+<td class="signwriting">񁛱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00116.html">S13f</a></td>
-<td>񁞱</td>
-<td></td>
+<td class="signwriting">񁞱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td>2finNonspread_othersFist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00118.html">S1a3</a></td>
-<td>񃴱</td>
-<td></td>
+<td class="signwriting">񃴱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00121.html">S128</a></td>
-<td>񀼑</td>
-<td></td>
+<td class="signwriting">񀼑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00131.html">S17d</a></td>
-<td>񂻱</td>
-<td></td>
+<td class="signwriting">񂻱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td>4finSpread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00137.html">S155</a></td>
-<td>񁿱</td>
-<td></td>
+<td class="signwriting">񁿱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -460,8 +486,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00140.html">S18b</a></td>
-<td>񃐱</td>
-<td></td>
+<td class="signwriting">񃐱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -469,8 +495,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00143.html">S1ba</a></td>
-<td>񄗁</td>
-<td></td>
+<td class="signwriting">񄗁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -478,8 +504,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -487,8 +513,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00146.html">S1d0</a></td>
-<td>񄸑</td>
-<td></td>
+<td class="signwriting">񄸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -496,8 +522,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00147.html">S1d5</a></td>
-<td>񄿱</td>
-<td></td>
+<td class="signwriting">񄿱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -505,8 +531,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00150.html">S18c</a></td>
-<td>񃒑</td>
-<td></td>
+<td class="signwriting">񃒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -514,8 +540,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00152.html">S1da</a></td>
-<td>񅇑</td>
-<td></td>
+<td class="signwriting">񅇑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -523,8 +549,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00153.html">S1c1</a></td>
-<td>񄡱</td>
-<td></td>
+<td class="signwriting">񄡱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -532,8 +558,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00154.html">S1c3</a></td>
-<td>񄤱</td>
-<td></td>
+<td class="signwriting">񄤱</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00005.html
+++ b/inventories/inv00005.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>SSL, STS (LQ_5)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>SSL, STS (LQ_5)</h1>
@@ -55,8 +81,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00004.html">S203</a></td>
-<td>񆄱</td>
-<td>񆅁</td>
+<td class="signwriting">񆄱</td>
+<td class="signwriting">񆅁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00011.html">S201</a></td>
-<td>񆁱</td>
-<td></td>
+<td class="signwriting">񆁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00020.html">S1c6</a></td>
-<td>񄩁</td>
-<td>񄩑</td>
+<td class="signwriting">񄩁</td>
+<td class="signwriting">񄩑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00025.html">S10c</a></td>
-<td>񀒑</td>
-<td></td>
+<td class="signwriting">񀒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00043.html">S118</a></td>
-<td>񀤑</td>
-<td></td>
+<td class="signwriting">񀤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00054.html">S1a0</a></td>
-<td>񃰑</td>
-<td></td>
+<td class="signwriting">񃰑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00082.html">S14b</a></td>
-<td>񁰱</td>
-<td></td>
+<td class="signwriting">񁰱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00103.html">S1c5</a></td>
-<td>񄧱</td>
-<td></td>
+<td class="signwriting">񄧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00105.html">S1e5</a></td>
-<td>񅗱</td>
-<td></td>
+<td class="signwriting">񅗱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00114.html">S129</a></td>
-<td>񀽱</td>
-<td></td>
+<td class="signwriting">񀽱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00116.html">S13f</a></td>
-<td>񁞱</td>
-<td></td>
+<td class="signwriting">񁞱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00131.html">S17d</a></td>
-<td>񂻱</td>
-<td></td>
+<td class="signwriting">񂻱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td>4finNonspread</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00133.html">S160</a></td>
-<td>񂐑</td>
-<td></td>
+<td class="signwriting">񂐑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00134.html">S153</a></td>
-<td>񁼱</td>
-<td></td>
+<td class="signwriting">񁼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00139.html">S187</a></td>
-<td>񃊱</td>
-<td></td>
+<td class="signwriting">񃊱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00144.html">S1bb</a></td>
-<td>񄘱</td>
-<td></td>
+<td class="signwriting">񄘱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00150.html">S18c</a></td>
-<td>񃒑</td>
-<td></td>
+<td class="signwriting">񃒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00159.html">S1d8</a></td>
-<td>񅄑</td>
-<td></td>
+<td class="signwriting">񅄑</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00006.html
+++ b/inventories/inv00006.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>BSL (LQ_6)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>BSL (LQ_6)</h1>
@@ -55,8 +81,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00003.html">S1f8</a></td>
-<td>񅴑</td>
-<td></td>
+<td class="signwriting">񅴑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00004.html">S203</a></td>
-<td>񆄱</td>
-<td>񆅁</td>
+<td class="signwriting">񆄱</td>
+<td class="signwriting">񆅁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00020.html">S1c6</a></td>
-<td>񄩁</td>
-<td>񄩑</td>
+<td class="signwriting">񄩁</td>
+<td class="signwriting">񄩑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00025.html">S10c</a></td>
-<td>񀒑</td>
-<td></td>
+<td class="signwriting">񀒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00031.html">S1e1</a></td>
-<td>񅑱</td>
-<td>񅑡</td>
+<td class="signwriting">񅑱</td>
+<td class="signwriting">񅑡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00039.html">S119</a></td>
-<td>񀥱</td>
-<td></td>
+<td class="signwriting">񀥱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00043.html">S118</a></td>
-<td>񀤑</td>
-<td></td>
+<td class="signwriting">񀤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00053.html">S19c</a></td>
-<td>񃪑</td>
-<td></td>
+<td class="signwriting">񃪑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00054.html">S1a0</a></td>
-<td>񃰑</td>
-<td></td>
+<td class="signwriting">񃰑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00055.html">S1b0</a></td>
-<td>񄈑</td>
-<td></td>
+<td class="signwriting">񄈑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>3_nonspread</td>
 <td>extended</td>
 <td><a href="../segments/seg00066.html">S18e</a></td>
-<td>񃕑</td>
-<td></td>
+<td class="signwriting">񃕑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>3_spread</td>
 <td>extended</td>
 <td><a href="../segments/seg00074.html">S1c4</a></td>
-<td>񄦑</td>
-<td></td>
+<td class="signwriting">񄦑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00083.html">S180</a></td>
-<td>񃀑</td>
-<td>񃀁</td>
+<td class="signwriting">񃀑</td>
+<td class="signwriting">񃀁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00087.html">S16e</a></td>
-<td>񂥑</td>
-<td></td>
+<td class="signwriting">񂥑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00088.html">S170</a></td>
-<td>񂨑</td>
-<td></td>
+<td class="signwriting">񂨑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00108.html">S1ed</a></td>
-<td>񅣡</td>
-<td>񅢑</td>
+<td class="signwriting">񅣡</td>
+<td class="signwriting">񅢑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00113.html">S1f4</a></td>
-<td>񅮁</td>
-<td>񅮑</td>
+<td class="signwriting">񅮁</td>
+<td class="signwriting">񅮑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00114.html">S129</a></td>
-<td>񀽱</td>
-<td></td>
+<td class="signwriting">񀽱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00116.html">S13f</a></td>
-<td>񁞱</td>
-<td></td>
+<td class="signwriting">񁞱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td>2finNonspread_othersFist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00118.html">S1a3</a></td>
-<td>񃴱</td>
-<td></td>
+<td class="signwriting">񃴱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00121.html">S128</a></td>
-<td>񀼑</td>
-<td></td>
+<td class="signwriting">񀼑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00127.html">S173</a></td>
-<td>񂬱</td>
-<td></td>
+<td class="signwriting">񂬱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -460,8 +486,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00131.html">S17d</a></td>
-<td>񂻱</td>
-<td></td>
+<td class="signwriting">񂻱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -469,8 +495,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -478,8 +504,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00134.html">S153</a></td>
-<td>񁼱</td>
-<td></td>
+<td class="signwriting">񁼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -487,8 +513,8 @@
 <td>4finSpread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00137.html">S155</a></td>
-<td>񁿱</td>
-<td></td>
+<td class="signwriting">񁿱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -496,8 +522,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00139.html">S187</a></td>
-<td>񃊱</td>
-<td></td>
+<td class="signwriting">񃊱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -505,8 +531,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00141.html">S1a4</a></td>
-<td>񃶁</td>
-<td></td>
+<td class="signwriting">񃶁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -514,8 +540,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -523,8 +549,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00150.html">S18c</a></td>
-<td>񃒑</td>
-<td></td>
+<td class="signwriting">񃒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -532,8 +558,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00151.html">S18d</a></td>
-<td>񃓱</td>
-<td></td>
+<td class="signwriting">񃓱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -541,8 +567,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00154.html">S1c3</a></td>
-<td>񄤱</td>
-<td></td>
+<td class="signwriting">񄤱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -550,8 +576,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00156.html">S1d2</a></td>
-<td>񄻑</td>
-<td></td>
+<td class="signwriting">񄻑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -559,8 +585,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00158.html">S1d4</a></td>
-<td>񄾑</td>
-<td></td>
+<td class="signwriting">񄾑</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00007.html
+++ b/inventories/inv00007.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Auslan (LQ_7)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Auslan (LQ_7)</h1>
@@ -55,8 +81,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00003.html">S1f8</a></td>
-<td>񅴑</td>
-<td></td>
+<td class="signwriting">񅴑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00004.html">S203</a></td>
-<td>񆄱</td>
-<td>񆅁</td>
+<td class="signwriting">񆄱</td>
+<td class="signwriting">񆅁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00014.html">S103</a></td>
-<td>񀄱</td>
-<td></td>
+<td class="signwriting">񀄱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00031.html">S1e1</a></td>
-<td>񅑱</td>
-<td>񅑡</td>
+<td class="signwriting">񅑱</td>
+<td class="signwriting">񅑡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00053.html">S19c</a></td>
-<td>񃪑</td>
-<td></td>
+<td class="signwriting">񃪑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00054.html">S1a0</a></td>
-<td>񃰑</td>
-<td></td>
+<td class="signwriting">񃰑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00083.html">S180</a></td>
-<td>񃀑</td>
-<td>񃀁</td>
+<td class="signwriting">񃀑</td>
+<td class="signwriting">񃀁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00103.html">S1c5</a></td>
-<td>񄧱</td>
-<td></td>
+<td class="signwriting">񄧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00106.html">S1e7</a></td>
-<td>񅚱</td>
-<td></td>
+<td class="signwriting">񅚱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00108.html">S1ed</a></td>
-<td>񅣡</td>
-<td>񅢑</td>
+<td class="signwriting">񅣡</td>
+<td class="signwriting">񅢑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00113.html">S1f4</a></td>
-<td>񅮁</td>
-<td>񅮑</td>
+<td class="signwriting">񅮁</td>
+<td class="signwriting">񅮑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00116.html">S13f</a></td>
-<td>񁞱</td>
-<td></td>
+<td class="signwriting">񁞱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00131.html">S17d</a></td>
-<td>񂻱</td>
-<td></td>
+<td class="signwriting">񂻱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00134.html">S153</a></td>
-<td>񁼱</td>
-<td></td>
+<td class="signwriting">񁼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00139.html">S187</a></td>
-<td>񃊱</td>
-<td></td>
+<td class="signwriting">񃊱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00144.html">S1bb</a></td>
-<td>񄘱</td>
-<td></td>
+<td class="signwriting">񄘱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00150.html">S18c</a></td>
-<td>񃒑</td>
-<td></td>
+<td class="signwriting">񃒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00158.html">S1d4</a></td>
-<td>񄾑</td>
-<td></td>
+<td class="signwriting">񄾑</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00008.html
+++ b/inventories/inv00008.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>NZSL (LQ_8)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>NZSL (LQ_8)</h1>
@@ -55,8 +81,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00003.html">S1f8</a></td>
-<td>񅴑</td>
-<td></td>
+<td class="signwriting">񅴑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00004.html">S203</a></td>
-<td>񆄱</td>
-<td>񆅁</td>
+<td class="signwriting">񆄱</td>
+<td class="signwriting">񆅁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00011.html">S201</a></td>
-<td>񆁱</td>
-<td></td>
+<td class="signwriting">񆁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00020.html">S1c6</a></td>
-<td>񄩁</td>
-<td>񄩑</td>
+<td class="signwriting">񄩁</td>
+<td class="signwriting">񄩑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00025.html">S10c</a></td>
-<td>񀒑</td>
-<td></td>
+<td class="signwriting">񀒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00031.html">S1e1</a></td>
-<td>񅑱</td>
-<td>񅑡</td>
+<td class="signwriting">񅑱</td>
+<td class="signwriting">񅑡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00039.html">S119</a></td>
-<td>񀥱</td>
-<td></td>
+<td class="signwriting">񀥱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00043.html">S118</a></td>
-<td>񀤑</td>
-<td></td>
+<td class="signwriting">񀤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00054.html">S1a0</a></td>
-<td>񃰑</td>
-<td></td>
+<td class="signwriting">񃰑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00059.html">S123</a></td>
-<td>񀴱</td>
-<td></td>
+<td class="signwriting">񀴱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00061.html">S121</a></td>
-<td>񀱱</td>
-<td></td>
+<td class="signwriting">񀱱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00089.html">S171</a></td>
-<td>񂩱</td>
-<td></td>
+<td class="signwriting">񂩱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00090.html">S202</a></td>
-<td>񆃑</td>
-<td></td>
+<td class="signwriting">񆃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00095.html">S158</a></td>
-<td>񂄑</td>
-<td></td>
+<td class="signwriting">񂄑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00098.html">S14e</a></td>
-<td>񁵑</td>
-<td></td>
+<td class="signwriting">񁵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00103.html">S1c5</a></td>
-<td>񄧱</td>
-<td></td>
+<td class="signwriting">񄧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00105.html">S1e5</a></td>
-<td>񅗱</td>
-<td></td>
+<td class="signwriting">񅗱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00110.html">S1e4</a></td>
-<td>񅖑</td>
-<td></td>
+<td class="signwriting">񅖑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00113.html">S1f4</a></td>
-<td>񅮁</td>
-<td>񅮑</td>
+<td class="signwriting">񅮁</td>
+<td class="signwriting">񅮑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00114.html">S129</a></td>
-<td>񀽱</td>
-<td></td>
+<td class="signwriting">񀽱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00115.html">S13d</a></td>
-<td>񁛡</td>
-<td>񁛱</td>
+<td class="signwriting">񁛡</td>
+<td class="signwriting">񁛱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00116.html">S13f</a></td>
-<td>񁞱</td>
-<td></td>
+<td class="signwriting">񁞱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00124.html">S127</a></td>
-<td>񀺱</td>
-<td></td>
+<td class="signwriting">񀺱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -460,8 +486,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -469,8 +495,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -478,8 +504,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00131.html">S17d</a></td>
-<td>񂻱</td>
-<td></td>
+<td class="signwriting">񂻱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -487,8 +513,8 @@
 <td>4finNonspread</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00133.html">S160</a></td>
-<td>񂐑</td>
-<td></td>
+<td class="signwriting">񂐑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -496,8 +522,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00134.html">S153</a></td>
-<td>񁼱</td>
-<td></td>
+<td class="signwriting">񁼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -505,8 +531,8 @@
 <td>4finSpread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00137.html">S155</a></td>
-<td>񁿱</td>
-<td></td>
+<td class="signwriting">񁿱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -514,8 +540,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00139.html">S187</a></td>
-<td>񃊱</td>
-<td></td>
+<td class="signwriting">񃊱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -523,8 +549,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00140.html">S18b</a></td>
-<td>񃐱</td>
-<td></td>
+<td class="signwriting">񃐱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -532,8 +558,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00144.html">S1bb</a></td>
-<td>񄘱</td>
-<td></td>
+<td class="signwriting">񄘱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -541,8 +567,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -550,8 +576,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00150.html">S18c</a></td>
-<td>񃒑</td>
-<td></td>
+<td class="signwriting">񃒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -559,8 +585,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00154.html">S1c3</a></td>
-<td>񄤱</td>
-<td></td>
+<td class="signwriting">񄤱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -568,8 +594,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00158.html">S1d4</a></td>
-<td>񄾑</td>
-<td></td>
+<td class="signwriting">񄾑</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00009.html
+++ b/inventories/inv00009.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>TSL (LQ_9)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>TSL (LQ_9)</h1>
@@ -55,8 +81,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00004.html">S203</a></td>
-<td>񆄱</td>
-<td>񆅁</td>
+<td class="signwriting">񆄱</td>
+<td class="signwriting">񆅁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00008.html">S1fd</a></td>
-<td>񅼁</td>
-<td>񅻱</td>
+<td class="signwriting">񅼁</td>
+<td class="signwriting">񅻱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00014.html">S103</a></td>
-<td>񀄱</td>
-<td></td>
+<td class="signwriting">񀄱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00019.html">S1ae</a></td>
-<td>񄅑</td>
-<td></td>
+<td class="signwriting">񄅑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00020.html">S1c6</a></td>
-<td>񄩁</td>
-<td>񄩑</td>
+<td class="signwriting">񄩁</td>
+<td class="signwriting">񄩑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00022.html">S1de</a></td>
-<td>񅍑</td>
-<td></td>
+<td class="signwriting">񅍑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00024.html">S1e0</a></td>
-<td>񅐁</td>
-<td>񅐑</td>
+<td class="signwriting">񅐁</td>
+<td class="signwriting">񅐑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00026.html">S1f2</a></td>
-<td>񅫁</td>
-<td></td>
+<td class="signwriting">񅫁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00030.html">S198</a></td>
-<td>񃤑</td>
-<td></td>
+<td class="signwriting">񃤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00041.html">S13e</a></td>
-<td>񁝑</td>
-<td></td>
+<td class="signwriting">񁝑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00063.html">S126</a></td>
-<td>񀹑</td>
-<td></td>
+<td class="signwriting">񀹑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00053.html">S19c</a></td>
-<td>񃪑</td>
-<td></td>
+<td class="signwriting">񃪑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00054.html">S1a0</a></td>
-<td>񃰑</td>
-<td></td>
+<td class="signwriting">񃰑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00057.html">S1cb</a></td>
-<td>񄰱</td>
-<td></td>
+<td class="signwriting">񄰱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00058.html">S112</a></td>
-<td>񀛑</td>
-<td></td>
+<td class="signwriting">񀛑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00065.html">S142</a></td>
-<td>񁣑</td>
-<td></td>
+<td class="signwriting">񁣑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>3_nonspread</td>
 <td>extended</td>
 <td><a href="../segments/seg00066.html">S18e</a></td>
-<td>񃕑</td>
-<td></td>
+<td class="signwriting">񃕑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>3_spread</td>
 <td>bent</td>
 <td><a href="../segments/seg00076.html">S190</a></td>
-<td>񃘑</td>
-<td></td>
+<td class="signwriting">񃘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00097.html">S145</a></td>
-<td>񁧱</td>
-<td></td>
+<td class="signwriting">񁧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00103.html">S1c5</a></td>
-<td>񄧱</td>
-<td></td>
+<td class="signwriting">񄧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00104.html">S199</a></td>
-<td>񃥱</td>
-<td></td>
+<td class="signwriting">񃥱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00108.html">S1ed</a></td>
-<td>񅣡</td>
-<td>񅢑</td>
+<td class="signwriting">񅣡</td>
+<td class="signwriting">񅢑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00116.html">S13f</a></td>
-<td>񁞱</td>
-<td></td>
+<td class="signwriting">񁞱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td>2finNonspread_othersFist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00118.html">S1a3</a></td>
-<td>񃴱</td>
-<td></td>
+<td class="signwriting">񃴱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td>2finNonspread_othersFist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00120.html">S1b3</a></td>
-<td>񄌱</td>
-<td></td>
+<td class="signwriting">񄌱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -460,8 +486,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -469,8 +495,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -478,8 +504,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00131.html">S17d</a></td>
-<td>񂻱</td>
-<td></td>
+<td class="signwriting">񂻱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -487,8 +513,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -496,8 +522,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00134.html">S153</a></td>
-<td>񁼱</td>
-<td></td>
+<td class="signwriting">񁼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -505,8 +531,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00139.html">S187</a></td>
-<td>񃊱</td>
-<td></td>
+<td class="signwriting">񃊱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -514,8 +540,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00140.html">S18b</a></td>
-<td>񃐱</td>
-<td></td>
+<td class="signwriting">񃐱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -523,8 +549,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -532,8 +558,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00146.html">S1d0</a></td>
-<td>񄸑</td>
-<td></td>
+<td class="signwriting">񄸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -541,8 +567,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00150.html">S18c</a></td>
-<td>񃒑</td>
-<td></td>
+<td class="signwriting">񃒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -550,8 +576,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00154.html">S1c3</a></td>
-<td>񄤱</td>
-<td></td>
+<td class="signwriting">񄤱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -559,8 +585,8 @@
 <td>1fin_othersNonfist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00161.html">S196</a></td>
-<td>񃡑</td>
-<td></td>
+<td class="signwriting">񃡑</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00010.html
+++ b/inventories/inv00010.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>KSL (LQ_10)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>KSL (LQ_10)</h1>
@@ -55,8 +81,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00003.html">S1f8</a></td>
-<td>񅴑</td>
-<td></td>
+<td class="signwriting">񅴑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00004.html">S203</a></td>
-<td>񆄱</td>
-<td>񆅁</td>
+<td class="signwriting">񆄱</td>
+<td class="signwriting">񆅁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00005.html">S1f9</a></td>
-<td>񅵱</td>
-<td></td>
+<td class="signwriting">񅵱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00009.html">S1ff</a></td>
-<td>񅾱</td>
-<td></td>
+<td class="signwriting">񅾱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00010.html">S200</a></td>
-<td>񆀑</td>
-<td></td>
+<td class="signwriting">񆀑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00022.html">S1de</a></td>
-<td>񅍑</td>
-<td></td>
+<td class="signwriting">񅍑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00023.html">S1df</a></td>
-<td>񅎱</td>
-<td></td>
+<td class="signwriting">񅎱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00030.html">S198</a></td>
-<td>񃤑</td>
-<td></td>
+<td class="signwriting">񃤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00032.html">S1e2</a></td>
-<td>񅓁</td>
-<td></td>
+<td class="signwriting">񅓁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00038.html">S1b5</a></td>
-<td>񄏱</td>
-<td></td>
+<td class="signwriting">񄏱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00046.html">S116</a></td>
-<td>񀡑</td>
-<td></td>
+<td class="signwriting">񀡑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00054.html">S1a0</a></td>
-<td>񃰑</td>
-<td></td>
+<td class="signwriting">񃰑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00056.html">S1b4</a></td>
-<td>񄎑</td>
-<td></td>
+<td class="signwriting">񄎑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00061.html">S121</a></td>
-<td>񀱱</td>
-<td></td>
+<td class="signwriting">񀱱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00063.html">S126</a></td>
-<td>񀹑</td>
-<td></td>
+<td class="signwriting">񀹑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>3_nonspread</td>
 <td>extended</td>
 <td><a href="../segments/seg00066.html">S18e</a></td>
-<td>񃕑</td>
-<td></td>
+<td class="signwriting">񃕑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00141.html">S1a4</a></td>
-<td>񃶁</td>
-<td></td>
+<td class="signwriting">񃶁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>3_spread</td>
 <td>bent</td>
 <td><a href="../segments/seg00076.html">S190</a></td>
-<td>񃘑</td>
-<td></td>
+<td class="signwriting">񃘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00088.html">S170</a></td>
-<td>񂨑</td>
-<td></td>
+<td class="signwriting">񂨑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td>4_nonspread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00091.html">S1d7</a></td>
-<td>񅂱</td>
-<td></td>
+<td class="signwriting">񅂱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00096.html">S159</a></td>
-<td>񂅱</td>
-<td></td>
+<td class="signwriting">񂅱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00097.html">S145</a></td>
-<td>񁧱</td>
-<td></td>
+<td class="signwriting">񁧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00098.html">S14e</a></td>
-<td>񁵑</td>
-<td></td>
+<td class="signwriting">񁵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00105.html">S1e5</a></td>
-<td>񅗱</td>
-<td></td>
+<td class="signwriting">񅗱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00108.html">S1ed</a></td>
-<td>񅣡</td>
-<td>񅢑</td>
+<td class="signwriting">񅣡</td>
+<td class="signwriting">񅢑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td>1fin_othersFist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00109.html">S19f</a></td>
-<td>񃮱</td>
-<td></td>
+<td class="signwriting">񃮱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00113.html">S1f4</a></td>
-<td>񅮁</td>
-<td>񅮑</td>
+<td class="signwriting">񅮁</td>
+<td class="signwriting">񅮑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -460,8 +486,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00114.html">S129</a></td>
-<td>񀽱</td>
-<td></td>
+<td class="signwriting">񀽱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -469,8 +495,8 @@
 <td>2finNonspread_othersFist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00119.html">S1b2</a></td>
-<td>񄋑</td>
-<td></td>
+<td class="signwriting">񄋑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -478,8 +504,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00123.html">S12b</a></td>
-<td>񁀱</td>
-<td></td>
+<td class="signwriting">񁀱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -487,8 +513,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -496,8 +522,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -505,8 +531,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -514,8 +540,8 @@
 <td>4finNonspread</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00133.html">S160</a></td>
-<td>񂐑</td>
-<td></td>
+<td class="signwriting">񂐑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -523,8 +549,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00134.html">S153</a></td>
-<td>񁼱</td>
-<td></td>
+<td class="signwriting">񁼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -532,8 +558,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00139.html">S187</a></td>
-<td>񃊱</td>
-<td></td>
+<td class="signwriting">񃊱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -541,8 +567,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00140.html">S18b</a></td>
-<td>񃐱</td>
-<td></td>
+<td class="signwriting">񃐱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -550,8 +576,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00144.html">S1bb</a></td>
-<td>񄘱</td>
-<td></td>
+<td class="signwriting">񄘱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -559,8 +585,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -568,8 +594,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00146.html">S1d0</a></td>
-<td>񄸑</td>
-<td></td>
+<td class="signwriting">񄸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -577,8 +603,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00148.html">S1d6</a></td>
-<td>񅁑</td>
-<td></td>
+<td class="signwriting">񅁑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -586,8 +612,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00150.html">S18c</a></td>
-<td>񃒑</td>
-<td></td>
+<td class="signwriting">񃒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -595,8 +621,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00153.html">S1c1</a></td>
-<td>񄡱</td>
-<td></td>
+<td class="signwriting">񄡱</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00011.html
+++ b/inventories/inv00011.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>DSL, DTS (LQ_11)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>DSL, DTS (LQ_11)</h1>
@@ -55,8 +81,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00003.html">S1f8</a></td>
-<td>񅴑</td>
-<td></td>
+<td class="signwriting">񅴑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00004.html">S203</a></td>
-<td>񆄱</td>
-<td>񆅁</td>
+<td class="signwriting">񆄱</td>
+<td class="signwriting">񆅁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00020.html">S1c6</a></td>
-<td>񄩁</td>
-<td>񄩑</td>
+<td class="signwriting">񄩁</td>
+<td class="signwriting">񄩑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00022.html">S1de</a></td>
-<td>񅍑</td>
-<td></td>
+<td class="signwriting">񅍑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00025.html">S10c</a></td>
-<td>񀒑</td>
-<td></td>
+<td class="signwriting">񀒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00026.html">S1f2</a></td>
-<td>񅫁</td>
-<td></td>
+<td class="signwriting">񅫁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00031.html">S1e1</a></td>
-<td>񅑱</td>
-<td>񅑡</td>
+<td class="signwriting">񅑱</td>
+<td class="signwriting">񅑡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00040.html">S132</a></td>
-<td>񁋑</td>
-<td></td>
+<td class="signwriting">񁋑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00043.html">S118</a></td>
-<td>񀤑</td>
-<td></td>
+<td class="signwriting">񀤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00052.html">S125</a></td>
-<td>񀷱</td>
-<td></td>
+<td class="signwriting">񀷱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00053.html">S19c</a></td>
-<td>񃪑</td>
-<td></td>
+<td class="signwriting">񃪑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00054.html">S1a0</a></td>
-<td>񃰑</td>
-<td></td>
+<td class="signwriting">񃰑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00062.html">S122</a></td>
-<td>񀳑</td>
-<td></td>
+<td class="signwriting">񀳑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00083.html">S180</a></td>
-<td>񃀑</td>
-<td>񃀁</td>
+<td class="signwriting">񃀑</td>
+<td class="signwriting">񃀁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00085.html">S149</a></td>
-<td>񁭱</td>
-<td></td>
+<td class="signwriting">񁭱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00086.html">S168</a></td>
-<td>񂜑</td>
-<td></td>
+<td class="signwriting">񂜑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00090.html">S202</a></td>
-<td>񆃑</td>
-<td></td>
+<td class="signwriting">񆃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00098.html">S14e</a></td>
-<td>񁵑</td>
-<td></td>
+<td class="signwriting">񁵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00103.html">S1c5</a></td>
-<td>񄧱</td>
-<td></td>
+<td class="signwriting">񄧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00108.html">S1ed</a></td>
-<td>񅣡</td>
-<td>񅢑</td>
+<td class="signwriting">񅣡</td>
+<td class="signwriting">񅢑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00113.html">S1f4</a></td>
-<td>񅮁</td>
-<td>񅮑</td>
+<td class="signwriting">񅮁</td>
+<td class="signwriting">񅮑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00114.html">S129</a></td>
-<td>񀽱</td>
-<td></td>
+<td class="signwriting">񀽱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -460,8 +486,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00115.html">S13d</a></td>
-<td>񁛡</td>
-<td>񁛱</td>
+<td class="signwriting">񁛡</td>
+<td class="signwriting">񁛱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -469,8 +495,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00116.html">S13f</a></td>
-<td>񁞱</td>
-<td></td>
+<td class="signwriting">񁞱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -478,8 +504,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00123.html">S12b</a></td>
-<td>񁀱</td>
-<td></td>
+<td class="signwriting">񁀱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -487,8 +513,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -496,8 +522,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -505,8 +531,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00131.html">S17d</a></td>
-<td>񂻱</td>
-<td></td>
+<td class="signwriting">񂻱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -514,8 +540,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -523,8 +549,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00134.html">S153</a></td>
-<td>񁼱</td>
-<td></td>
+<td class="signwriting">񁼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -532,8 +558,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00139.html">S187</a></td>
-<td>񃊱</td>
-<td></td>
+<td class="signwriting">񃊱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -541,8 +567,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00141.html">S1a4</a></td>
-<td>񃶁</td>
-<td></td>
+<td class="signwriting">񃶁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -550,8 +576,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00143.html">S1ba</a></td>
-<td>񄗁</td>
-<td></td>
+<td class="signwriting">񄗁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -559,8 +585,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -568,8 +594,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00151.html">S18d</a></td>
-<td>񃓱</td>
-<td></td>
+<td class="signwriting">񃓱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -577,8 +603,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00155.html">S1d1</a></td>
-<td>񄹱</td>
-<td></td>
+<td class="signwriting">񄹱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -586,8 +612,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00156.html">S1d2</a></td>
-<td>񄻑</td>
-<td></td>
+<td class="signwriting">񄻑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -595,8 +621,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00158.html">S1d4</a></td>
-<td>񄾑</td>
-<td></td>
+<td class="signwriting">񄾑</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00012.html
+++ b/inventories/inv00012.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>NGT, SLN (LQ_12)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>NGT, SLN (LQ_12)</h1>
@@ -55,8 +81,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00003.html">S1f8</a></td>
-<td>񅴑</td>
-<td></td>
+<td class="signwriting">񅴑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00004.html">S203</a></td>
-<td>񆄱</td>
-<td>񆅁</td>
+<td class="signwriting">񆄱</td>
+<td class="signwriting">񆅁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00006.html">S1fb</a></td>
-<td>񅸱</td>
-<td></td>
+<td class="signwriting">񅸱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00011.html">S201</a></td>
-<td>񆁱</td>
-<td></td>
+<td class="signwriting">񆁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00015.html">S108</a></td>
-<td>񀌑</td>
-<td></td>
+<td class="signwriting">񀌑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00017.html">S193</a></td>
-<td>񃜱</td>
-<td></td>
+<td class="signwriting">񃜱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00020.html">S1c6</a></td>
-<td>񄩁</td>
-<td>񄩑</td>
+<td class="signwriting">񄩁</td>
+<td class="signwriting">񄩑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00022.html">S1de</a></td>
-<td>񅍑</td>
-<td></td>
+<td class="signwriting">񅍑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00023.html">S1df</a></td>
-<td>񅎱</td>
-<td></td>
+<td class="signwriting">񅎱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00026.html">S1f2</a></td>
-<td>񅫁</td>
-<td></td>
+<td class="signwriting">񅫁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00031.html">S1e1</a></td>
-<td>񅑱</td>
-<td>񅑡</td>
+<td class="signwriting">񅑱</td>
+<td class="signwriting">񅑡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00039.html">S119</a></td>
-<td>񀥱</td>
-<td></td>
+<td class="signwriting">񀥱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00043.html">S118</a></td>
-<td>񀤑</td>
-<td></td>
+<td class="signwriting">񀤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00052.html">S125</a></td>
-<td>񀷱</td>
-<td></td>
+<td class="signwriting">񀷱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00053.html">S19c</a></td>
-<td>񃪑</td>
-<td></td>
+<td class="signwriting">񃪑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00062.html">S122</a></td>
-<td>񀳑</td>
-<td></td>
+<td class="signwriting">񀳑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>3_spread</td>
 <td>extended</td>
 <td><a href="../segments/seg00071.html">S18f</a></td>
-<td>񃖱</td>
-<td></td>
+<td class="signwriting">񃖱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00087.html">S16e</a></td>
-<td>񂥑</td>
-<td></td>
+<td class="signwriting">񂥑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00088.html">S170</a></td>
-<td>񂨑</td>
-<td></td>
+<td class="signwriting">񂨑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00095.html">S158</a></td>
-<td>񂄑</td>
-<td></td>
+<td class="signwriting">񂄑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00096.html">S159</a></td>
-<td>񂅱</td>
-<td></td>
+<td class="signwriting">񂅱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00102.html">S1a7</a></td>
-<td>񃺱</td>
-<td></td>
+<td class="signwriting">񃺱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00103.html">S1c5</a></td>
-<td>񄧱</td>
-<td></td>
+<td class="signwriting">񄧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -460,8 +486,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00108.html">S1ed</a></td>
-<td>񅣡</td>
-<td>񅢑</td>
+<td class="signwriting">񅣡</td>
+<td class="signwriting">񅢑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -469,8 +495,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00111.html">S1ee</a></td>
-<td>񅥑</td>
-<td></td>
+<td class="signwriting">񅥑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -478,8 +504,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -487,8 +513,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00113.html">S1f4</a></td>
-<td>񅮁</td>
-<td>񅮑</td>
+<td class="signwriting">񅮁</td>
+<td class="signwriting">񅮑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -496,8 +522,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00114.html">S129</a></td>
-<td>񀽱</td>
-<td></td>
+<td class="signwriting">񀽱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -505,8 +531,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00115.html">S13d</a></td>
-<td>񁛡</td>
-<td>񁛱</td>
+<td class="signwriting">񁛡</td>
+<td class="signwriting">񁛱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -514,8 +540,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00116.html">S13f</a></td>
-<td>񁞱</td>
-<td></td>
+<td class="signwriting">񁞱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -523,8 +549,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00121.html">S128</a></td>
-<td>񀼑</td>
-<td></td>
+<td class="signwriting">񀼑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -532,8 +558,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00122.html">S12a</a></td>
-<td>񀿑</td>
-<td></td>
+<td class="signwriting">񀿑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -541,8 +567,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00123.html">S12b</a></td>
-<td>񁀱</td>
-<td></td>
+<td class="signwriting">񁀱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -550,8 +576,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -559,8 +585,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -568,8 +594,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -577,8 +603,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00130.html">S17c</a></td>
-<td>񂺑</td>
-<td></td>
+<td class="signwriting">񂺑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -586,8 +612,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00131.html">S17d</a></td>
-<td>񂻱</td>
-<td></td>
+<td class="signwriting">񂻱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -595,8 +621,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -604,8 +630,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00135.html">S154</a></td>
-<td>񁾑</td>
-<td></td>
+<td class="signwriting">񁾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -613,8 +639,8 @@
 <td>4finSpread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00137.html">S155</a></td>
-<td>񁿱</td>
-<td></td>
+<td class="signwriting">񁿱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -622,8 +648,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00139.html">S187</a></td>
-<td>񃊱</td>
-<td></td>
+<td class="signwriting">񃊱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -631,8 +657,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00140.html">S18b</a></td>
-<td>񃐱</td>
-<td></td>
+<td class="signwriting">񃐱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -640,8 +666,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00142.html">S1a5</a></td>
-<td>񃷱</td>
-<td></td>
+<td class="signwriting">񃷱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -649,8 +675,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00144.html">S1bb</a></td>
-<td>񄘱</td>
-<td></td>
+<td class="signwriting">񄘱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -658,8 +684,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -667,8 +693,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00151.html">S18d</a></td>
-<td>񃓱</td>
-<td></td>
+<td class="signwriting">񃓱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -676,8 +702,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00154.html">S1c3</a></td>
-<td>񄤱</td>
-<td></td>
+<td class="signwriting">񄤱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -685,8 +711,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00155.html">S1d1</a></td>
-<td>񄹱</td>
-<td></td>
+<td class="signwriting">񄹱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -694,8 +720,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00157.html">S1d3</a></td>
-<td>񄼱</td>
-<td></td>
+<td class="signwriting">񄼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -703,8 +729,8 @@
 <td>1fin_othersNonfist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00160.html">S105</a></td>
-<td>񀇱</td>
-<td></td>
+<td class="signwriting">񀇱</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00013.html
+++ b/inventories/inv00013.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>AFSL (SP_106)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>AFSL (SP_106)</h1>
@@ -55,8 +81,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00101.html">S157</a></td>
-<td>񂂱</td>
-<td></td>
+<td class="signwriting">񂂱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00014.html
+++ b/inventories/inv00014.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>AlbSL (SP_82)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>AlbSL (SP_82)</h1>
@@ -55,8 +81,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00108.html">S1ed</a></td>
-<td>񅣡</td>
-<td>񅢑</td>
+<td class="signwriting">񅣡</td>
+<td class="signwriting">񅢑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00166.html">S17e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00164.html">S14d</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00114.html">S129</a></td>
-<td>񀽱</td>
-<td></td>
+<td class="signwriting">񀽱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00022.html">S1de</a></td>
-<td>񅍑</td>
-<td></td>
+<td class="signwriting">񅍑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00167.html">S1cd</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00025.html">S10c</a></td>
-<td>񀒑</td>
-<td></td>
+<td class="signwriting">񀒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00162.html">S10b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00098.html">S14e</a></td>
-<td>񁵑</td>
-<td></td>
+<td class="signwriting">񁵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00152.html">S1da</a></td>
-<td>񅇑</td>
-<td></td>
+<td class="signwriting">񅇑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00113.html">S1f4</a></td>
-<td>񅮁</td>
-<td>񅮑</td>
+<td class="signwriting">񅮁</td>
+<td class="signwriting">񅮑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00168.html">S1dd</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00156.html">S1d2</a></td>
-<td>񄻑</td>
-<td></td>
+<td class="signwriting">񄻑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00163.html">S14a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00083.html">S180</a></td>
-<td>񃀑</td>
-<td>񃀁</td>
+<td class="signwriting">񃀑</td>
+<td class="signwriting">񃀁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00165.html">S16f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00031.html">S1e1</a></td>
-<td>񅑱</td>
-<td>񅑡</td>
+<td class="signwriting">񅑱</td>
+<td class="signwriting">񅑡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00015.html
+++ b/inventories/inv00015.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>LSA (SP_41)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>LSA (SP_41)</h1>
@@ -55,8 +81,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>4finSpread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00137.html">S155</a></td>
-<td>񁿱</td>
-<td></td>
+<td class="signwriting">񁿱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00108.html">S1ed</a></td>
-<td>񅣡</td>
-<td>񅢑</td>
+<td class="signwriting">񅣡</td>
+<td class="signwriting">񅢑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00158.html">S1d4</a></td>
-<td>񄾑</td>
-<td></td>
+<td class="signwriting">񄾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00054.html">S1a0</a></td>
-<td>񃰑</td>
-<td></td>
+<td class="signwriting">񃰑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00101.html">S157</a></td>
-<td>񂂱</td>
-<td></td>
+<td class="signwriting">񂂱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00134.html">S153</a></td>
-<td>񁼱</td>
-<td></td>
+<td class="signwriting">񁼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00111.html">S1ee</a></td>
-<td>񅥑</td>
-<td></td>
+<td class="signwriting">񅥑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00274.html">S1ef</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00083.html">S180</a></td>
-<td>񃀑</td>
-<td>񃀁</td>
+<td class="signwriting">񃀑</td>
+<td class="signwriting">񃀁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00256.html">S1bc</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00275.html">S1f1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td>4finNonspread</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00133.html">S160</a></td>
-<td>񂐑</td>
-<td></td>
+<td class="signwriting">񂐑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00025.html">S10c</a></td>
-<td>񀒑</td>
-<td></td>
+<td class="signwriting">񀒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00204.html">S152</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00110.html">S1e4</a></td>
-<td>񅖑</td>
-<td></td>
+<td class="signwriting">񅖑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00155.html">S1d1</a></td>
-<td>񄹱</td>
-<td></td>
+<td class="signwriting">񄹱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00154.html">S1c3</a></td>
-<td>񄤱</td>
-<td></td>
+<td class="signwriting">񄤱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00003.html">S1f8</a></td>
-<td>񅴑</td>
-<td></td>
+<td class="signwriting">񅴑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -460,8 +486,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00103.html">S1c5</a></td>
-<td>񄧱</td>
-<td></td>
+<td class="signwriting">񄧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -469,8 +495,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00216.html">S167</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -478,8 +504,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00146.html">S1d0</a></td>
-<td>񄸑</td>
-<td></td>
+<td class="signwriting">񄸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -487,8 +513,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00113.html">S1f4</a></td>
-<td>񅮁</td>
-<td>񅮑</td>
+<td class="signwriting">񅮁</td>
+<td class="signwriting">񅮑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -496,8 +522,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00261.html">S1c2</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -505,8 +531,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00273.html">S1ec</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -514,8 +540,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00222.html">S174</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -523,8 +549,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00048.html">S11d</a></td>
-<td>񀫡</td>
-<td></td>
+<td class="signwriting">񀫡</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -532,8 +558,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00220.html">S16c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -541,8 +567,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -550,8 +576,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00166.html">S17e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -559,8 +585,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00043.html">S118</a></td>
-<td>񀤑</td>
-<td></td>
+<td class="signwriting">񀤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -568,8 +594,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00144.html">S1bb</a></td>
-<td>񄘱</td>
-<td></td>
+<td class="signwriting">񄘱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -577,8 +603,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00232.html">S186</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -586,8 +612,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00095.html">S158</a></td>
-<td>񂄑</td>
-<td></td>
+<td class="signwriting">񂄑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -595,8 +621,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00156.html">S1d2</a></td>
-<td>񄻑</td>
-<td></td>
+<td class="signwriting">񄻑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -604,8 +630,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00229.html">S181</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -613,8 +639,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00116.html">S13f</a></td>
-<td>񁞱</td>
-<td></td>
+<td class="signwriting">񁞱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -622,8 +648,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00026.html">S1f2</a></td>
-<td>񅫁</td>
-<td></td>
+<td class="signwriting">񅫁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -631,8 +657,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00135.html">S154</a></td>
-<td>񁾑</td>
-<td></td>
+<td class="signwriting">񁾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -640,8 +666,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00205.html">S156</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -649,8 +675,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00131.html">S17d</a></td>
-<td>񂻱</td>
-<td></td>
+<td class="signwriting">񂻱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -658,8 +684,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00031.html">S1e1</a></td>
-<td>񅑱</td>
-<td>񅑡</td>
+<td class="signwriting">񅑱</td>
+<td class="signwriting">񅑡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -667,8 +693,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00039.html">S119</a></td>
-<td>񀥱</td>
-<td></td>
+<td class="signwriting">񀥱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -676,8 +702,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00030.html">S198</a></td>
-<td>񃤑</td>
-<td></td>
+<td class="signwriting">񃤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -685,8 +711,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00089.html">S171</a></td>
-<td>񂩱</td>
-<td></td>
+<td class="signwriting">񂩱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -694,8 +720,8 @@
 <td>2finNonspread_othersFist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00118.html">S1a3</a></td>
-<td>񃴱</td>
-<td></td>
+<td class="signwriting">񃴱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -703,8 +729,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00190.html">S134</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -712,8 +738,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00130.html">S17c</a></td>
-<td>񂺑</td>
-<td></td>
+<td class="signwriting">񂺑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -721,8 +747,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00165.html">S16f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -730,8 +756,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00085.html">S149</a></td>
-<td>񁭱</td>
-<td></td>
+<td class="signwriting">񁭱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -739,8 +765,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00243.html">S1a1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -748,8 +774,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00181.html">S11f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -757,8 +783,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -766,8 +792,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00189.html">S133</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -775,8 +801,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00173.html">S10d</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -784,8 +810,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00215.html">S166</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -793,8 +819,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00106.html">S1e7</a></td>
-<td>񅚱</td>
-<td></td>
+<td class="signwriting">񅚱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -802,8 +828,8 @@
 <td>3_spread</td>
 <td>extended</td>
 <td><a href="../segments/seg00074.html">S1c4</a></td>
-<td>񄦑</td>
-<td></td>
+<td class="signwriting">񄦑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -811,8 +837,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00267.html">S1cf</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -820,8 +846,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00193.html">S137</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -829,8 +855,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00198.html">S13c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -838,8 +864,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00014.html">S103</a></td>
-<td>񀄱</td>
-<td></td>
+<td class="signwriting">񀄱</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00016.html
+++ b/inventories/inv00016.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ÖGS (SP_29)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>ÖGS (SP_29)</h1>
@@ -55,8 +81,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00017.html
+++ b/inventories/inv00017.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Auslan (SP_42)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Auslan (SP_42)</h1>
@@ -55,8 +81,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00144.html">S1bb</a></td>
-<td>񄘱</td>
-<td></td>
+<td class="signwriting">񄘱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00003.html">S1f8</a></td>
-<td>񅴑</td>
-<td></td>
+<td class="signwriting">񅴑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00134.html">S153</a></td>
-<td>񁼱</td>
-<td></td>
+<td class="signwriting">񁼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00164.html">S14d</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00202.html">S14f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00204.html">S152</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00230.html">S183</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00059.html">S123</a></td>
-<td>񀴱</td>
-<td></td>
+<td class="signwriting">񀴱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00098.html">S14e</a></td>
-<td>񁵑</td>
-<td></td>
+<td class="signwriting">񁵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00222.html">S174</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00176.html">S113</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00214.html">S165</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00232.html">S186</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00150.html">S18c</a></td>
-<td>񃒑</td>
-<td></td>
+<td class="signwriting">񃒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00166.html">S17e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00046.html">S116</a></td>
-<td>񀡑</td>
-<td></td>
+<td class="signwriting">񀡑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00043.html">S118</a></td>
-<td>񀤑</td>
-<td></td>
+<td class="signwriting">񀤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00058.html">S112</a></td>
-<td>񀛑</td>
-<td></td>
+<td class="signwriting">񀛑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00115.html">S13d</a></td>
-<td>񁛡</td>
-<td>񁛱</td>
+<td class="signwriting">񁛡</td>
+<td class="signwriting">񁛱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00257.html">S1bd</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00185.html">S12e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00190.html">S134</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00225.html">S179</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00253.html">S1b7</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00116.html">S13f</a></td>
-<td>񁞱</td>
-<td></td>
+<td class="signwriting">񁞱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00101.html">S157</a></td>
-<td>񂂱</td>
-<td></td>
+<td class="signwriting">񂂱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td>3_spread</td>
 <td>extended</td>
 <td><a href="../segments/seg00073.html">S1ab</a></td>
-<td>񄀱</td>
-<td></td>
+<td class="signwriting">񄀱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00183.html">S124</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -460,8 +486,8 @@
 <td>1fin_othersNonfist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00161.html">S196</a></td>
-<td>񃡑</td>
-<td></td>
+<td class="signwriting">񃡑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -469,8 +495,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00206.html">S15b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -478,8 +504,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00082.html">S14b</a></td>
-<td>񁰱</td>
-<td></td>
+<td class="signwriting">񁰱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -487,8 +513,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00135.html">S154</a></td>
-<td>񁾑</td>
-<td></td>
+<td class="signwriting">񁾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -496,8 +522,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00199.html">S141</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -505,8 +531,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00141.html">S1a4</a></td>
-<td>񃶁</td>
-<td></td>
+<td class="signwriting">񃶁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -514,8 +540,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00097.html">S145</a></td>
-<td>񁧱</td>
-<td></td>
+<td class="signwriting">񁧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -523,8 +549,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00171.html">S107</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -532,8 +558,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00163.html">S14a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -541,8 +567,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00277.html">S1fa</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -550,8 +576,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00005.html">S1f9</a></td>
-<td>񅵱</td>
-<td></td>
+<td class="signwriting">񅵱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -559,8 +585,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00087.html">S16e</a></td>
-<td>񂥑</td>
-<td></td>
+<td class="signwriting">񂥑</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00018.html
+++ b/inventories/inv00018.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>LSFB (SP_43)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>LSFB (SP_43)</h1>
@@ -55,8 +81,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00083.html">S180</a></td>
-<td>񃀑</td>
-<td>񃀁</td>
+<td class="signwriting">񃀑</td>
+<td class="signwriting">񃀁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00158.html">S1d4</a></td>
-<td>񄾑</td>
-<td></td>
+<td class="signwriting">񄾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00135.html">S154</a></td>
-<td>񁾑</td>
-<td></td>
+<td class="signwriting">񁾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00098.html">S14e</a></td>
-<td>񁵑</td>
-<td></td>
+<td class="signwriting">񁵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00103.html">S1c5</a></td>
-<td>񄧱</td>
-<td></td>
+<td class="signwriting">񄧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00031.html">S1e1</a></td>
-<td>񅑱</td>
-<td>񅑡</td>
+<td class="signwriting">񅑱</td>
+<td class="signwriting">񅑡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00108.html">S1ed</a></td>
-<td>񅣡</td>
-<td>񅢑</td>
+<td class="signwriting">񅣡</td>
+<td class="signwriting">񅢑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00227.html">S17b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00113.html">S1f4</a></td>
-<td>񅮁</td>
-<td>񅮑</td>
+<td class="signwriting">񅮁</td>
+<td class="signwriting">񅮑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00111.html">S1ee</a></td>
-<td>񅥑</td>
-<td></td>
+<td class="signwriting">񅥑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00131.html">S17d</a></td>
-<td>񂻱</td>
-<td></td>
+<td class="signwriting">񂻱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00101.html">S157</a></td>
-<td>񂂱</td>
-<td></td>
+<td class="signwriting">񂂱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00273.html">S1ec</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00039.html">S119</a></td>
-<td>񀥱</td>
-<td></td>
+<td class="signwriting">񀥱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00114.html">S129</a></td>
-<td>񀽱</td>
-<td></td>
+<td class="signwriting">񀽱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00232.html">S186</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00165.html">S16f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00144.html">S1bb</a></td>
-<td>񄘱</td>
-<td></td>
+<td class="signwriting">񄘱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00134.html">S153</a></td>
-<td>񁼱</td>
-<td></td>
+<td class="signwriting">񁼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -460,8 +486,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -469,8 +495,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00040.html">S132</a></td>
-<td>񁋑</td>
-<td></td>
+<td class="signwriting">񁋑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -478,8 +504,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -487,8 +513,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00082.html">S14b</a></td>
-<td>񁰱</td>
-<td></td>
+<td class="signwriting">񁰱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -496,8 +522,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00155.html">S1d1</a></td>
-<td>񄹱</td>
-<td></td>
+<td class="signwriting">񄹱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -505,8 +531,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00156.html">S1d2</a></td>
-<td>񄻑</td>
-<td></td>
+<td class="signwriting">񄻑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -514,8 +540,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00061.html">S121</a></td>
-<td>񀱱</td>
-<td></td>
+<td class="signwriting">񀱱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -523,8 +549,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00025.html">S10c</a></td>
-<td>񀒑</td>
-<td></td>
+<td class="signwriting">񀒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -532,8 +558,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00116.html">S13f</a></td>
-<td>񁞱</td>
-<td></td>
+<td class="signwriting">񁞱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -541,8 +567,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00121.html">S128</a></td>
-<td>񀼑</td>
-<td></td>
+<td class="signwriting">񀼑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -550,8 +576,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -559,8 +585,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00183.html">S124</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -568,8 +594,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00097.html">S145</a></td>
-<td>񁧱</td>
-<td></td>
+<td class="signwriting">񁧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -577,8 +603,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00054.html">S1a0</a></td>
-<td>񃰑</td>
-<td></td>
+<td class="signwriting">񃰑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -586,8 +612,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00115.html">S13d</a></td>
-<td>񁛡</td>
-<td>񁛱</td>
+<td class="signwriting">񁛡</td>
+<td class="signwriting">񁛱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -595,8 +621,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00043.html">S118</a></td>
-<td>񀤑</td>
-<td></td>
+<td class="signwriting">񀤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -604,8 +630,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00274.html">S1ef</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -613,8 +639,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00085.html">S149</a></td>
-<td>񁭱</td>
-<td></td>
+<td class="signwriting">񁭱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -622,8 +648,8 @@
 <td>3_spread</td>
 <td>bent</td>
 <td><a href="../segments/seg00076.html">S190</a></td>
-<td>񃘑</td>
-<td></td>
+<td class="signwriting">񃘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -631,8 +657,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00005.html">S1f9</a></td>
-<td>񅵱</td>
-<td></td>
+<td class="signwriting">񅵱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -640,8 +666,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00153.html">S1c1</a></td>
-<td>񄡱</td>
-<td></td>
+<td class="signwriting">񄡱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -649,8 +675,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00127.html">S173</a></td>
-<td>񂬱</td>
-<td></td>
+<td class="signwriting">񂬱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -658,8 +684,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00123.html">S12b</a></td>
-<td>񁀱</td>
-<td></td>
+<td class="signwriting">񁀱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -667,8 +693,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00190.html">S134</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -676,8 +702,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00172.html">S109</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -685,8 +711,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -694,8 +720,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00053.html">S19c</a></td>
-<td>񃪑</td>
-<td></td>
+<td class="signwriting">񃪑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -703,8 +729,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00176.html">S113</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -712,8 +738,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00146.html">S1d0</a></td>
-<td>񄸑</td>
-<td></td>
+<td class="signwriting">񄸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -721,8 +747,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -730,8 +756,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00157.html">S1d3</a></td>
-<td>񄼱</td>
-<td></td>
+<td class="signwriting">񄼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -739,8 +765,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00124.html">S127</a></td>
-<td>񀺱</td>
-<td></td>
+<td class="signwriting">񀺱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -748,8 +774,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00140.html">S18b</a></td>
-<td>񃐱</td>
-<td></td>
+<td class="signwriting">񃐱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -757,8 +783,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00024.html">S1e0</a></td>
-<td>񅐁</td>
-<td>񅐑</td>
+<td class="signwriting">񅐁</td>
+<td class="signwriting">񅐑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -766,8 +792,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00065.html">S142</a></td>
-<td>񁣑</td>
-<td></td>
+<td class="signwriting">񁣑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -775,8 +801,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00163.html">S14a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -784,8 +810,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00224.html">S178</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -793,8 +819,8 @@
 <td>1fin_othersFist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00109.html">S19f</a></td>
-<td>񃮱</td>
-<td></td>
+<td class="signwriting">񃮱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -802,8 +828,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00243.html">S1a1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -811,8 +837,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00139.html">S187</a></td>
-<td>񃊱</td>
-<td></td>
+<td class="signwriting">񃊱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -820,8 +846,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00260.html">S1c0</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -829,8 +855,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00089.html">S171</a></td>
-<td>񂩱</td>
-<td></td>
+<td class="signwriting">񂩱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -838,8 +864,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00020.html">S1c6</a></td>
-<td>񄩁</td>
-<td>񄩑</td>
+<td class="signwriting">񄩁</td>
+<td class="signwriting">񄩑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -847,8 +873,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00239.html">S197</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -856,8 +882,8 @@
 <td>3_nonspread</td>
 <td>extended</td>
 <td><a href="../segments/seg00066.html">S18e</a></td>
-<td>񃕑</td>
-<td></td>
+<td class="signwriting">񃕑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -865,8 +891,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00189.html">S133</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -874,8 +900,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00022.html">S1de</a></td>
-<td>񅍑</td>
-<td></td>
+<td class="signwriting">񅍑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -883,8 +909,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00258.html">S1be</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -892,8 +918,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00159.html">S1d8</a></td>
-<td>񅄑</td>
-<td></td>
+<td class="signwriting">񅄑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -901,8 +927,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00151.html">S18d</a></td>
-<td>񃓱</td>
-<td></td>
+<td class="signwriting">񃓱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -910,8 +936,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00216.html">S167</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -919,8 +945,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00194.html">S138</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -928,8 +954,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00247.html">S1a9</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -937,8 +963,8 @@
 <td>3_spread</td>
 <td>extended</td>
 <td><a href="../segments/seg00074.html">S1c4</a></td>
-<td>񄦑</td>
-<td></td>
+<td class="signwriting">񄦑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -946,8 +972,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00154.html">S1c3</a></td>
-<td>񄤱</td>
-<td></td>
+<td class="signwriting">񄤱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -955,8 +981,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00006.html">S1fb</a></td>
-<td>񅸱</td>
-<td></td>
+<td class="signwriting">񅸱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -964,8 +990,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00169.html">S102</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -973,8 +999,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00222.html">S174</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -982,8 +1008,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00267.html">S1cf</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -991,8 +1017,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00198.html">S13c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00019.html
+++ b/inventories/inv00019.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>VGT (SP_44)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>VGT (SP_44)</h1>
@@ -55,8 +81,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00158.html">S1d4</a></td>
-<td>񄾑</td>
-<td></td>
+<td class="signwriting">񄾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00083.html">S180</a></td>
-<td>񃀑</td>
-<td>񃀁</td>
+<td class="signwriting">񃀑</td>
+<td class="signwriting">񃀁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00108.html">S1ed</a></td>
-<td>񅣡</td>
-<td>񅢑</td>
+<td class="signwriting">񅣡</td>
+<td class="signwriting">񅢑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00135.html">S154</a></td>
-<td>񁾑</td>
-<td></td>
+<td class="signwriting">񁾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00031.html">S1e1</a></td>
-<td>񅑱</td>
-<td>񅑡</td>
+<td class="signwriting">񅑱</td>
+<td class="signwriting">񅑡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00103.html">S1c5</a></td>
-<td>񄧱</td>
-<td></td>
+<td class="signwriting">񄧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00134.html">S153</a></td>
-<td>񁼱</td>
-<td></td>
+<td class="signwriting">񁼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00131.html">S17d</a></td>
-<td>񂻱</td>
-<td></td>
+<td class="signwriting">񂻱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00043.html">S118</a></td>
-<td>񀤑</td>
-<td></td>
+<td class="signwriting">񀤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00165.html">S16f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00274.html">S1ef</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00039.html">S119</a></td>
-<td>񀥱</td>
-<td></td>
+<td class="signwriting">񀥱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00065.html">S142</a></td>
-<td>񁣑</td>
-<td></td>
+<td class="signwriting">񁣑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00111.html">S1ee</a></td>
-<td>񅥑</td>
-<td></td>
+<td class="signwriting">񅥑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00273.html">S1ec</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00089.html">S171</a></td>
-<td>񂩱</td>
-<td></td>
+<td class="signwriting">񂩱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00144.html">S1bb</a></td>
-<td>񄘱</td>
-<td></td>
+<td class="signwriting">񄘱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00098.html">S14e</a></td>
-<td>񁵑</td>
-<td></td>
+<td class="signwriting">񁵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00166.html">S17e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -460,8 +486,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -469,8 +495,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00127.html">S173</a></td>
-<td>񂬱</td>
-<td></td>
+<td class="signwriting">񂬱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -478,8 +504,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00227.html">S17b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -487,8 +513,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00204.html">S152</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -496,8 +522,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00114.html">S129</a></td>
-<td>񀽱</td>
-<td></td>
+<td class="signwriting">񀽱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -505,8 +531,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00005.html">S1f9</a></td>
-<td>񅵱</td>
-<td></td>
+<td class="signwriting">񅵱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -514,8 +540,8 @@
 <td>4finSpread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00137.html">S155</a></td>
-<td>񁿱</td>
-<td></td>
+<td class="signwriting">񁿱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -523,8 +549,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00229.html">S181</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -532,8 +558,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00113.html">S1f4</a></td>
-<td>񅮁</td>
-<td>񅮑</td>
+<td class="signwriting">񅮁</td>
+<td class="signwriting">񅮑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -541,8 +567,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00220.html">S16c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -550,8 +576,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -559,8 +585,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00115.html">S13d</a></td>
-<td>񁛡</td>
-<td>񁛱</td>
+<td class="signwriting">񁛡</td>
+<td class="signwriting">񁛱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -568,8 +594,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00121.html">S128</a></td>
-<td>񀼑</td>
-<td></td>
+<td class="signwriting">񀼑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -577,8 +603,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -586,8 +612,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00101.html">S157</a></td>
-<td>񂂱</td>
-<td></td>
+<td class="signwriting">񂂱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -595,8 +621,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00232.html">S186</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -604,8 +630,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00139.html">S187</a></td>
-<td>񃊱</td>
-<td></td>
+<td class="signwriting">񃊱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -613,8 +639,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -622,8 +648,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00275.html">S1f1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -631,8 +657,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00163.html">S14a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -640,8 +666,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00228.html">S17f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -649,8 +675,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00162.html">S10b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -658,8 +684,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00116.html">S13f</a></td>
-<td>񁞱</td>
-<td></td>
+<td class="signwriting">񁞱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -667,8 +693,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00277.html">S1fa</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -676,8 +702,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00267.html">S1cf</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -685,8 +711,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00053.html">S19c</a></td>
-<td>񃪑</td>
-<td></td>
+<td class="signwriting">񃪑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -694,8 +720,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00155.html">S1d1</a></td>
-<td>񄹱</td>
-<td></td>
+<td class="signwriting">񄹱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -703,8 +729,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00130.html">S17c</a></td>
-<td>񂺑</td>
-<td></td>
+<td class="signwriting">񂺑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -712,8 +738,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00223.html">S175</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -721,8 +747,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00146.html">S1d0</a></td>
-<td>񄸑</td>
-<td></td>
+<td class="signwriting">񄸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -730,8 +756,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00097.html">S145</a></td>
-<td>񁧱</td>
-<td></td>
+<td class="signwriting">񁧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -739,8 +765,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00151.html">S18d</a></td>
-<td>񃓱</td>
-<td></td>
+<td class="signwriting">񃓱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -748,8 +774,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00205.html">S156</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -757,8 +783,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00216.html">S167</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -766,8 +792,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00224.html">S178</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -775,8 +801,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00156.html">S1d2</a></td>
-<td>񄻑</td>
-<td></td>
+<td class="signwriting">񄻑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -784,8 +810,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -793,8 +819,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00150.html">S18c</a></td>
-<td>񃒑</td>
-<td></td>
+<td class="signwriting">񃒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -802,8 +828,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00082.html">S14b</a></td>
-<td>񁰱</td>
-<td></td>
+<td class="signwriting">񁰱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -811,8 +837,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00259.html">S1bf</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -820,8 +846,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00167.html">S1cd</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -829,8 +855,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00032.html">S1e2</a></td>
-<td>񅓁</td>
-<td></td>
+<td class="signwriting">񅓁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -838,8 +864,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00003.html">S1f8</a></td>
-<td>񅴑</td>
-<td></td>
+<td class="signwriting">񅴑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -847,8 +873,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00022.html">S1de</a></td>
-<td>񅍑</td>
-<td></td>
+<td class="signwriting">񅍑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -856,8 +882,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00140.html">S18b</a></td>
-<td>񃐱</td>
-<td></td>
+<td class="signwriting">񃐱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -865,8 +891,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00157.html">S1d3</a></td>
-<td>񄼱</td>
-<td></td>
+<td class="signwriting">񄼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -874,8 +900,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00153.html">S1c1</a></td>
-<td>񄡱</td>
-<td></td>
+<td class="signwriting">񄡱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -883,8 +909,8 @@
 <td>4finNonspread</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00133.html">S160</a></td>
-<td>񂐑</td>
-<td></td>
+<td class="signwriting">񂐑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -892,8 +918,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00087.html">S16e</a></td>
-<td>񂥑</td>
-<td></td>
+<td class="signwriting">񂥑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -901,8 +927,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00194.html">S138</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -910,8 +936,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00026.html">S1f2</a></td>
-<td>񅫁</td>
-<td></td>
+<td class="signwriting">񅫁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -919,8 +945,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00123.html">S12b</a></td>
-<td>񁀱</td>
-<td></td>
+<td class="signwriting">񁀱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -928,8 +954,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00226.html">S17a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -937,8 +963,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00054.html">S1a0</a></td>
-<td>񃰑</td>
-<td></td>
+<td class="signwriting">񃰑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -946,8 +972,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00106.html">S1e7</a></td>
-<td>񅚱</td>
-<td></td>
+<td class="signwriting">񅚱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -955,8 +981,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00062.html">S122</a></td>
-<td>񀳑</td>
-<td></td>
+<td class="signwriting">񀳑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -964,8 +990,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00025.html">S10c</a></td>
-<td>񀒑</td>
-<td></td>
+<td class="signwriting">񀒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -973,8 +999,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00180.html">S11c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -982,8 +1008,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00154.html">S1c3</a></td>
-<td>񄤱</td>
-<td></td>
+<td class="signwriting">񄤱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -991,8 +1017,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00122.html">S12a</a></td>
-<td>񀿑</td>
-<td></td>
+<td class="signwriting">񀿑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1000,8 +1026,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00234.html">S189</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1009,8 +1035,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00225.html">S179</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1018,8 +1044,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00006.html">S1fb</a></td>
-<td>񅸱</td>
-<td></td>
+<td class="signwriting">񅸱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1027,8 +1053,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00176.html">S113</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1036,8 +1062,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00272.html">S1e8</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1045,8 +1071,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00222.html">S174</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1054,8 +1080,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00040.html">S132</a></td>
-<td>񁋑</td>
-<td></td>
+<td class="signwriting">񁋑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1063,8 +1089,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00094.html">S146</a></td>
-<td>񁩑</td>
-<td></td>
+<td class="signwriting">񁩑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1072,8 +1098,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00190.html">S134</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1081,8 +1107,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00095.html">S158</a></td>
-<td>񂄑</td>
-<td></td>
+<td class="signwriting">񂄑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1090,8 +1116,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00102.html">S1a7</a></td>
-<td>񃺱</td>
-<td></td>
+<td class="signwriting">񃺱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1099,8 +1125,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00174.html">S10f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1108,8 +1134,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00221.html">S172</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1117,8 +1143,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00237.html">S194</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1126,8 +1152,8 @@
 <td>2finNonspread_othersFist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00118.html">S1a3</a></td>
-<td>񃴱</td>
-<td></td>
+<td class="signwriting">񃴱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1135,8 +1161,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00152.html">S1da</a></td>
-<td>񅇑</td>
-<td></td>
+<td class="signwriting">񅇑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1144,8 +1170,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00245.html">S1a6</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1153,8 +1179,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00058.html">S112</a></td>
-<td>񀛑</td>
-<td></td>
+<td class="signwriting">񀛑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1162,8 +1188,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00217.html">S169</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1171,8 +1197,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00020.html">S1c6</a></td>
-<td>񄩁</td>
-<td>񄩑</td>
+<td class="signwriting">񄩁</td>
+<td class="signwriting">񄩑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1180,8 +1206,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00181.html">S11f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1189,8 +1215,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00203.html">S151</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1198,8 +1224,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00061.html">S121</a></td>
-<td>񀱱</td>
-<td></td>
+<td class="signwriting">񀱱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1207,8 +1233,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00246.html">S1a8</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1216,8 +1242,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00241.html">S19d</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1225,8 +1251,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00023.html">S1df</a></td>
-<td>񅎱</td>
-<td></td>
+<td class="signwriting">񅎱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1234,8 +1260,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00085.html">S149</a></td>
-<td>񁭱</td>
-<td></td>
+<td class="signwriting">񁭱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1243,8 +1269,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00242.html">S19e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1252,8 +1278,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00182.html">S120</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1261,8 +1287,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00088.html">S170</a></td>
-<td>񂨑</td>
-<td></td>
+<td class="signwriting">񂨑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1270,8 +1296,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00271.html">S1e6</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1279,8 +1305,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00209.html">S15f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00020.html
+++ b/inventories/inv00020.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>BZhE (SP_134)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>BZhE (SP_134)</h1>
@@ -55,8 +81,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00131.html">S17d</a></td>
-<td>񂻱</td>
-<td></td>
+<td class="signwriting">񂻱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00021.html
+++ b/inventories/inv00021.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>LSB (SP_45)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>LSB (SP_45)</h1>
@@ -55,8 +81,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00022.html
+++ b/inventories/inv00022.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Libras (SP_46)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Libras (SP_46)</h1>
@@ -55,8 +81,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00163.html">S14a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00134.html">S153</a></td>
-<td>񁼱</td>
-<td></td>
+<td class="signwriting">񁼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00108.html">S1ed</a></td>
-<td>񅣡</td>
-<td>񅢑</td>
+<td class="signwriting">񅣡</td>
+<td class="signwriting">񅢑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00039.html">S119</a></td>
-<td>񀥱</td>
-<td></td>
+<td class="signwriting">񀥱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00101.html">S157</a></td>
-<td>񂂱</td>
-<td></td>
+<td class="signwriting">񂂱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00151.html">S18d</a></td>
-<td>񃓱</td>
-<td></td>
+<td class="signwriting">񃓱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00156.html">S1d2</a></td>
-<td>񄻑</td>
-<td></td>
+<td class="signwriting">񄻑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00157.html">S1d3</a></td>
-<td>񄼱</td>
-<td></td>
+<td class="signwriting">񄼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00232.html">S186</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00003.html">S1f8</a></td>
-<td>񅴑</td>
-<td></td>
+<td class="signwriting">񅴑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00083.html">S180</a></td>
-<td>񃀑</td>
-<td>񃀁</td>
+<td class="signwriting">񃀑</td>
+<td class="signwriting">񃀁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00162.html">S10b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00113.html">S1f4</a></td>
-<td>񅮁</td>
-<td>񅮑</td>
+<td class="signwriting">񅮁</td>
+<td class="signwriting">񅮑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00022.html">S1de</a></td>
-<td>񅍑</td>
-<td></td>
+<td class="signwriting">񅍑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00150.html">S18c</a></td>
-<td>񃒑</td>
-<td></td>
+<td class="signwriting">񃒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00043.html">S118</a></td>
-<td>񀤑</td>
-<td></td>
+<td class="signwriting">񀤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00135.html">S154</a></td>
-<td>񁾑</td>
-<td></td>
+<td class="signwriting">񁾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00220.html">S16c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00158.html">S1d4</a></td>
-<td>񄾑</td>
-<td></td>
+<td class="signwriting">񄾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -460,8 +486,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00103.html">S1c5</a></td>
-<td>񄧱</td>
-<td></td>
+<td class="signwriting">񄧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -469,8 +495,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00131.html">S17d</a></td>
-<td>񂻱</td>
-<td></td>
+<td class="signwriting">񂻱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -478,8 +504,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -487,8 +513,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -496,8 +522,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -505,8 +531,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -514,8 +540,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00273.html">S1ec</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -523,8 +549,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00229.html">S181</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -532,8 +558,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00054.html">S1a0</a></td>
-<td>񃰑</td>
-<td></td>
+<td class="signwriting">񃰑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -541,8 +567,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00023.html">S1df</a></td>
-<td>񅎱</td>
-<td></td>
+<td class="signwriting">񅎱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -550,8 +576,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00111.html">S1ee</a></td>
-<td>񅥑</td>
-<td></td>
+<td class="signwriting">񅥑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -559,8 +585,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00065.html">S142</a></td>
-<td>񁣑</td>
-<td></td>
+<td class="signwriting">񁣑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -568,8 +594,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -577,8 +603,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00139.html">S187</a></td>
-<td>񃊱</td>
-<td></td>
+<td class="signwriting">񃊱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -586,8 +612,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00223.html">S175</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -595,8 +621,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00144.html">S1bb</a></td>
-<td>񄘱</td>
-<td></td>
+<td class="signwriting">񄘱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -604,8 +630,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00165.html">S16f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -613,8 +639,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00098.html">S14e</a></td>
-<td>񁵑</td>
-<td></td>
+<td class="signwriting">񁵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -622,8 +648,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00025.html">S10c</a></td>
-<td>񀒑</td>
-<td></td>
+<td class="signwriting">񀒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -631,8 +657,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00275.html">S1f1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -640,8 +666,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00277.html">S1fa</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -649,8 +675,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00274.html">S1ef</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -658,8 +684,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00166.html">S17e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -667,8 +693,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00228.html">S17f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -676,8 +702,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00053.html">S19c</a></td>
-<td>񃪑</td>
-<td></td>
+<td class="signwriting">񃪑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -685,8 +711,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00026.html">S1f2</a></td>
-<td>񅫁</td>
-<td></td>
+<td class="signwriting">񅫁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -694,8 +720,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00204.html">S152</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -703,8 +729,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00189.html">S133</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -712,8 +738,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00116.html">S13f</a></td>
-<td>񁞱</td>
-<td></td>
+<td class="signwriting">񁞱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -721,8 +747,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00089.html">S171</a></td>
-<td>񂩱</td>
-<td></td>
+<td class="signwriting">񂩱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -730,8 +756,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00115.html">S13d</a></td>
-<td>񁛡</td>
-<td>񁛱</td>
+<td class="signwriting">񁛡</td>
+<td class="signwriting">񁛱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -739,8 +765,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00110.html">S1e4</a></td>
-<td>񅖑</td>
-<td></td>
+<td class="signwriting">񅖑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -748,8 +774,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00154.html">S1c3</a></td>
-<td>񄤱</td>
-<td></td>
+<td class="signwriting">񄤱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -757,8 +783,8 @@
 <td>4finNonspread</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00133.html">S160</a></td>
-<td>񂐑</td>
-<td></td>
+<td class="signwriting">񂐑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -766,8 +792,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00121.html">S128</a></td>
-<td>񀼑</td>
-<td></td>
+<td class="signwriting">񀼑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -775,8 +801,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00146.html">S1d0</a></td>
-<td>񄸑</td>
-<td></td>
+<td class="signwriting">񄸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -784,8 +810,8 @@
 <td>4finSpread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00137.html">S155</a></td>
-<td>񁿱</td>
-<td></td>
+<td class="signwriting">񁿱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -793,8 +819,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00130.html">S17c</a></td>
-<td>񂺑</td>
-<td></td>
+<td class="signwriting">񂺑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -802,8 +828,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00155.html">S1d1</a></td>
-<td>񄹱</td>
-<td></td>
+<td class="signwriting">񄹱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -811,8 +837,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00127.html">S173</a></td>
-<td>񂬱</td>
-<td></td>
+<td class="signwriting">񂬱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -820,8 +846,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00203.html">S151</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -829,8 +855,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00124.html">S127</a></td>
-<td>񀺱</td>
-<td></td>
+<td class="signwriting">񀺱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -838,8 +864,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00222.html">S174</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -847,8 +873,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00153.html">S1c1</a></td>
-<td>񄡱</td>
-<td></td>
+<td class="signwriting">񄡱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -856,8 +882,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00140.html">S18b</a></td>
-<td>񃐱</td>
-<td></td>
+<td class="signwriting">񃐱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -865,8 +891,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00114.html">S129</a></td>
-<td>񀽱</td>
-<td></td>
+<td class="signwriting">񀽱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -874,8 +900,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00102.html">S1a7</a></td>
-<td>񃺱</td>
-<td></td>
+<td class="signwriting">񃺱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -883,8 +909,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00237.html">S194</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -892,8 +918,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00176.html">S113</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -901,8 +927,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00159.html">S1d8</a></td>
-<td>񅄑</td>
-<td></td>
+<td class="signwriting">񅄑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -910,8 +936,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00152.html">S1da</a></td>
-<td>񅇑</td>
-<td></td>
+<td class="signwriting">񅇑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -919,8 +945,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00030.html">S198</a></td>
-<td>񃤑</td>
-<td></td>
+<td class="signwriting">񃤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -928,8 +954,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00246.html">S1a8</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -937,8 +963,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00205.html">S156</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -946,8 +972,8 @@
 <td>2finNonspread_othersFist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00118.html">S1a3</a></td>
-<td>񃴱</td>
-<td></td>
+<td class="signwriting">񃴱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -955,8 +981,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00095.html">S158</a></td>
-<td>񂄑</td>
-<td></td>
+<td class="signwriting">񂄑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -964,8 +990,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00006.html">S1fb</a></td>
-<td>񅸱</td>
-<td></td>
+<td class="signwriting">񅸱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -973,8 +999,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00005.html">S1f9</a></td>
-<td>񅵱</td>
-<td></td>
+<td class="signwriting">񅵱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -982,8 +1008,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00040.html">S132</a></td>
-<td>񁋑</td>
-<td></td>
+<td class="signwriting">񁋑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -991,8 +1017,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00224.html">S178</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1000,8 +1026,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00227.html">S17b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1009,8 +1035,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00183.html">S124</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1018,8 +1044,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00082.html">S14b</a></td>
-<td>񁰱</td>
-<td></td>
+<td class="signwriting">񁰱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1027,8 +1053,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00062.html">S122</a></td>
-<td>񀳑</td>
-<td></td>
+<td class="signwriting">񀳑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1036,8 +1062,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00225.html">S179</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1045,8 +1071,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00174.html">S10f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1054,8 +1080,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00061.html">S121</a></td>
-<td>񀱱</td>
-<td></td>
+<td class="signwriting">񀱱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1063,8 +1089,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00142.html">S1a5</a></td>
-<td>񃷱</td>
-<td></td>
+<td class="signwriting">񃷱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1072,8 +1098,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00097.html">S145</a></td>
-<td>񁧱</td>
-<td></td>
+<td class="signwriting">񁧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1081,8 +1107,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00014.html">S103</a></td>
-<td>񀄱</td>
-<td></td>
+<td class="signwriting">񀄱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1090,8 +1116,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00215.html">S166</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1099,8 +1125,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00172.html">S109</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1108,8 +1134,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00209.html">S15f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1117,8 +1143,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00087.html">S16e</a></td>
-<td>񂥑</td>
-<td></td>
+<td class="signwriting">񂥑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1126,8 +1152,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00123.html">S12b</a></td>
-<td>񁀱</td>
-<td></td>
+<td class="signwriting">񁀱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1135,8 +1161,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00058.html">S112</a></td>
-<td>񀛑</td>
-<td></td>
+<td class="signwriting">񀛑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1144,8 +1170,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00169.html">S102</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1153,8 +1179,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00234.html">S189</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1162,8 +1188,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00094.html">S146</a></td>
-<td>񁩑</td>
-<td></td>
+<td class="signwriting">񁩑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1171,8 +1197,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00206.html">S15b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1180,8 +1206,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00261.html">S1c2</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1189,8 +1215,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00171.html">S107</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1198,8 +1224,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00210.html">S161</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1207,8 +1233,8 @@
 <td>3_spread</td>
 <td>bent</td>
 <td><a href="../segments/seg00076.html">S190</a></td>
-<td>񃘑</td>
-<td></td>
+<td class="signwriting">񃘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1216,8 +1242,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00027.html">S1f3</a></td>
-<td>񅬱</td>
-<td></td>
+<td class="signwriting">񅬱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1225,8 +1251,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00226.html">S17a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1234,8 +1260,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00173.html">S10d</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1243,8 +1269,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00031.html">S1e1</a></td>
-<td>񅑱</td>
-<td>񅑡</td>
+<td class="signwriting">񅑱</td>
+<td class="signwriting">񅑡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1252,8 +1278,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00194.html">S138</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1261,8 +1287,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00179.html">S11b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1270,8 +1296,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00272.html">S1e8</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1279,8 +1305,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00059.html">S123</a></td>
-<td>񀴱</td>
-<td></td>
+<td class="signwriting">񀴱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1288,8 +1314,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00221.html">S172</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1297,8 +1323,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00216.html">S167</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1306,8 +1332,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00048.html">S11d</a></td>
-<td>񀫡</td>
-<td></td>
+<td class="signwriting">񀫡</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1315,8 +1341,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00260.html">S1c0</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1324,8 +1350,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00191.html">S135</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1333,8 +1359,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00096.html">S159</a></td>
-<td>񂅱</td>
-<td></td>
+<td class="signwriting">񂅱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1342,8 +1368,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00184.html">S12c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1351,8 +1377,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00245.html">S1a6</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1360,8 +1386,8 @@
 <td>1fin_othersNonfist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00160.html">S105</a></td>
-<td>񀇱</td>
-<td></td>
+<td class="signwriting">񀇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1369,8 +1395,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00177.html">S114</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1378,8 +1404,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00198.html">S13c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1387,8 +1413,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00046.html">S116</a></td>
-<td>񀡑</td>
-<td></td>
+<td class="signwriting">񀡑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1396,8 +1422,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00085.html">S149</a></td>
-<td>񁭱</td>
-<td></td>
+<td class="signwriting">񁭱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1405,8 +1431,8 @@
 <td>3_spread</td>
 <td>extended</td>
 <td><a href="../segments/seg00071.html">S18f</a></td>
-<td>񃖱</td>
-<td></td>
+<td class="signwriting">񃖱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1414,8 +1440,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00122.html">S12a</a></td>
-<td>񀿑</td>
-<td></td>
+<td class="signwriting">񀿑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1423,8 +1449,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00088.html">S170</a></td>
-<td>񂨑</td>
-<td></td>
+<td class="signwriting">񂨑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1432,8 +1458,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00164.html">S14d</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1441,8 +1467,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00212.html">S163</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1450,8 +1476,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00264.html">S1c9</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1459,8 +1485,8 @@
 <td>3_nonspread</td>
 <td>extended</td>
 <td><a href="../segments/seg00066.html">S18e</a></td>
-<td>񃕑</td>
-<td></td>
+<td class="signwriting">񃕑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1468,8 +1494,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00038.html">S1b5</a></td>
-<td>񄏱</td>
-<td></td>
+<td class="signwriting">񄏱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1477,8 +1503,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00276.html">S1f6</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1486,8 +1512,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00185.html">S12e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1495,8 +1521,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00238.html">S195</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1504,8 +1530,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00233.html">S188</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1513,8 +1539,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00235.html">S18a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1522,8 +1548,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00052.html">S125</a></td>
-<td>񀷱</td>
-<td></td>
+<td class="signwriting">񀷱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1531,8 +1557,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00181.html">S11f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1540,8 +1566,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00230.html">S183</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1549,8 +1575,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00199.html">S141</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1558,8 +1584,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00211.html">S162</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1567,8 +1593,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00170.html">S104</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1576,8 +1602,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00190.html">S134</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1585,8 +1611,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00041.html">S13e</a></td>
-<td>񁝑</td>
-<td></td>
+<td class="signwriting">񁝑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1594,8 +1620,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00032.html">S1e2</a></td>
-<td>񅓁</td>
-<td></td>
+<td class="signwriting">񅓁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1603,8 +1629,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00180.html">S11c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1612,8 +1638,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00063.html">S126</a></td>
-<td>񀹑</td>
-<td></td>
+<td class="signwriting">񀹑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1621,8 +1647,8 @@
 <td>1fin_othersNonfist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00161.html">S196</a></td>
-<td>񃡑</td>
-<td></td>
+<td class="signwriting">񃡑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1630,8 +1656,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00267.html">S1cf</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1639,8 +1665,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00192.html">S136</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1648,8 +1674,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00178.html">S117</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1657,8 +1683,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00201.html">S148</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1666,8 +1692,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00241.html">S19d</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1675,8 +1701,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00207.html">S15c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1684,8 +1710,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00024.html">S1e0</a></td>
-<td>񅐁</td>
-<td>񅐑</td>
+<td class="signwriting">񅐁</td>
+<td class="signwriting">񅐑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1693,8 +1719,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00265.html">S1ca</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1702,8 +1728,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00217.html">S169</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1711,8 +1737,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00086.html">S168</a></td>
-<td>񂜑</td>
-<td></td>
+<td class="signwriting">񂜑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1720,8 +1746,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00239.html">S197</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1729,8 +1755,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00015.html">S108</a></td>
-<td>񀌑</td>
-<td></td>
+<td class="signwriting">񀌑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1738,8 +1764,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00254.html">S1b8</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1747,8 +1773,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00271.html">S1e6</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1756,8 +1782,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00141.html">S1a4</a></td>
-<td>񃶁</td>
-<td></td>
+<td class="signwriting">񃶁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1765,8 +1791,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00104.html">S199</a></td>
-<td>񃥱</td>
-<td></td>
+<td class="signwriting">񃥱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1774,8 +1800,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00182.html">S120</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1783,8 +1809,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00186.html">S12f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1792,8 +1818,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00055.html">S1b0</a></td>
-<td>񄈑</td>
-<td></td>
+<td class="signwriting">񄈑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1801,8 +1827,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00188.html">S131</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1810,8 +1836,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00200.html">S143</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1819,8 +1845,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00195.html">S139</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1828,8 +1854,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00219.html">S16b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1837,8 +1863,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00202.html">S14f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1846,8 +1872,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00020.html">S1c6</a></td>
-<td>񄩁</td>
-<td>񄩑</td>
+<td class="signwriting">񄩁</td>
+<td class="signwriting">񄩑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1855,8 +1881,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00105.html">S1e5</a></td>
-<td>񅗱</td>
-<td></td>
+<td class="signwriting">񅗱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1864,8 +1890,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00214.html">S165</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1873,8 +1899,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00197.html">S13b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1882,8 +1908,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00175.html">S111</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1891,8 +1917,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00196.html">S13a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1900,8 +1926,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00187.html">S130</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1909,8 +1935,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00218.html">S16a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1918,8 +1944,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00193.html">S137</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1927,8 +1953,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00236.html">S191</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1936,8 +1962,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00213.html">S164</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1945,8 +1971,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00106.html">S1e7</a></td>
-<td>񅚱</td>
-<td></td>
+<td class="signwriting">񅚱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1954,8 +1980,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00231.html">S184</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1963,8 +1989,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00143.html">S1ba</a></td>
-<td>񄗁</td>
-<td></td>
+<td class="signwriting">񄗁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1972,8 +1998,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00269.html">S1db</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1981,8 +2007,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00244.html">S1a2</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1990,8 +2016,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00017.html">S193</a></td>
-<td>񃜱</td>
-<td></td>
+<td class="signwriting">񃜱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1999,8 +2025,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00167.html">S1cd</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2008,8 +2034,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00266.html">S1cc</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2017,8 +2043,8 @@
 <td>1fin_othersFist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00109.html">S19f</a></td>
-<td>񃮱</td>
-<td></td>
+<td class="signwriting">񃮱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2026,8 +2052,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00247.html">S1a9</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2035,8 +2061,8 @@
 <td>2finNonspread_othersFist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00120.html">S1b3</a></td>
-<td>񄌱</td>
-<td></td>
+<td class="signwriting">񄌱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2044,8 +2070,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00250.html">S1af</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2053,8 +2079,8 @@
 <td>4_nonspread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00091.html">S1d7</a></td>
-<td>񅂱</td>
-<td></td>
+<td class="signwriting">񅂱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2062,8 +2088,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00259.html">S1bf</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2071,8 +2097,8 @@
 <td>3_spread</td>
 <td>extended</td>
 <td><a href="../segments/seg00074.html">S1c4</a></td>
-<td>񄦑</td>
-<td></td>
+<td class="signwriting">񄦑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2080,8 +2106,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00248.html">S1aa</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2089,8 +2115,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00253.html">S1b7</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2098,8 +2124,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00270.html">S1e3</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2107,8 +2133,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00147.html">S1d5</a></td>
-<td>񄿱</td>
-<td></td>
+<td class="signwriting">񄿱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2116,8 +2142,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00268.html">S1d9</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2125,8 +2151,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00007.html">S1fc</a></td>
-<td>񅺡</td>
-<td>񅺑</td>
+<td class="signwriting">񅺡</td>
+<td class="signwriting">񅺑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2134,8 +2160,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00243.html">S1a1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2143,8 +2169,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00208.html">S15e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2152,8 +2178,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00019.html">S1ae</a></td>
-<td>񄅑</td>
-<td></td>
+<td class="signwriting">񄅑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2161,8 +2187,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00240.html">S19b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2170,8 +2196,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00242.html">S19e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2179,8 +2205,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00057.html">S1cb</a></td>
-<td>񄰱</td>
-<td></td>
+<td class="signwriting">񄰱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2188,8 +2214,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00256.html">S1bc</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2197,8 +2223,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00008.html">S1fd</a></td>
-<td>񅼁</td>
-<td>񅻱</td>
+<td class="signwriting">񅼁</td>
+<td class="signwriting">񅻱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2206,8 +2232,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00258.html">S1be</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2215,8 +2241,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00056.html">S1b4</a></td>
-<td>񄎑</td>
-<td></td>
+<td class="signwriting">񄎑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2224,8 +2250,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00263.html">S1c8</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2233,8 +2259,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00009.html">S1ff</a></td>
-<td>񅾱</td>
-<td></td>
+<td class="signwriting">񅾱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2242,8 +2268,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00249.html">S1ac</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2251,8 +2277,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00255.html">S1b9</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2260,8 +2286,8 @@
 <td>2finNonspread_othersFist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00119.html">S1b2</a></td>
-<td>񄋑</td>
-<td></td>
+<td class="signwriting">񄋑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2269,8 +2295,8 @@
 <td>3_spread</td>
 <td>extended</td>
 <td><a href="../segments/seg00073.html">S1ab</a></td>
-<td>񄀱</td>
-<td></td>
+<td class="signwriting">񄀱</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00023.html
+++ b/inventories/inv00023.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ASL (SP_4)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>ASL (SP_4)</h1>
@@ -55,8 +81,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00083.html">S180</a></td>
-<td>񃀑</td>
-<td>񃀁</td>
+<td class="signwriting">񃀑</td>
+<td class="signwriting">񃀁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00103.html">S1c5</a></td>
-<td>񄧱</td>
-<td></td>
+<td class="signwriting">񄧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00006.html">S1fb</a></td>
-<td>񅸱</td>
-<td></td>
+<td class="signwriting">񅸱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00163.html">S14a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00039.html">S119</a></td>
-<td>񀥱</td>
-<td></td>
+<td class="signwriting">񀥱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00139.html">S187</a></td>
-<td>񃊱</td>
-<td></td>
+<td class="signwriting">񃊱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00098.html">S14e</a></td>
-<td>񁵑</td>
-<td></td>
+<td class="signwriting">񁵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00144.html">S1bb</a></td>
-<td>񄘱</td>
-<td></td>
+<td class="signwriting">񄘱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00151.html">S18d</a></td>
-<td>񃓱</td>
-<td></td>
+<td class="signwriting">񃓱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00043.html">S118</a></td>
-<td>񀤑</td>
-<td></td>
+<td class="signwriting">񀤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00158.html">S1d4</a></td>
-<td>񄾑</td>
-<td></td>
+<td class="signwriting">񄾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00134.html">S153</a></td>
-<td>񁼱</td>
-<td></td>
+<td class="signwriting">񁼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00142.html">S1a5</a></td>
-<td>񃷱</td>
-<td></td>
+<td class="signwriting">񃷱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00135.html">S154</a></td>
-<td>񁾑</td>
-<td></td>
+<td class="signwriting">񁾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00131.html">S17d</a></td>
-<td>񂻱</td>
-<td></td>
+<td class="signwriting">񂻱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00031.html">S1e1</a></td>
-<td>񅑱</td>
-<td>񅑡</td>
+<td class="signwriting">񅑱</td>
+<td class="signwriting">񅑡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -460,8 +486,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00232.html">S186</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -469,8 +495,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00065.html">S142</a></td>
-<td>񁣑</td>
-<td></td>
+<td class="signwriting">񁣑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -478,8 +504,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00053.html">S19c</a></td>
-<td>񃪑</td>
-<td></td>
+<td class="signwriting">񃪑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -487,8 +513,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00113.html">S1f4</a></td>
-<td>񅮁</td>
-<td>񅮑</td>
+<td class="signwriting">񅮁</td>
+<td class="signwriting">񅮑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -496,8 +522,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00229.html">S181</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -505,8 +531,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -514,8 +540,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00108.html">S1ed</a></td>
-<td>񅣡</td>
-<td>񅢑</td>
+<td class="signwriting">񅣡</td>
+<td class="signwriting">񅢑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -523,8 +549,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00165.html">S16f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -532,8 +558,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -541,8 +567,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00207.html">S15c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -550,8 +576,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00155.html">S1d1</a></td>
-<td>񄹱</td>
-<td></td>
+<td class="signwriting">񄹱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -559,8 +585,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00101.html">S157</a></td>
-<td>񂂱</td>
-<td></td>
+<td class="signwriting">񂂱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -568,8 +594,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00153.html">S1c1</a></td>
-<td>񄡱</td>
-<td></td>
+<td class="signwriting">񄡱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -577,8 +603,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00054.html">S1a0</a></td>
-<td>񃰑</td>
-<td></td>
+<td class="signwriting">񃰑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -586,8 +612,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00204.html">S152</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -595,8 +621,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00082.html">S14b</a></td>
-<td>񁰱</td>
-<td></td>
+<td class="signwriting">񁰱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -604,8 +630,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00274.html">S1ef</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -613,8 +639,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00220.html">S16c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -622,8 +648,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00166.html">S17e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -631,8 +657,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00203.html">S151</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -640,8 +666,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00277.html">S1fa</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -649,8 +675,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00040.html">S132</a></td>
-<td>񁋑</td>
-<td></td>
+<td class="signwriting">񁋑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -658,8 +684,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00116.html">S13f</a></td>
-<td>񁞱</td>
-<td></td>
+<td class="signwriting">񁞱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -667,8 +693,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00062.html">S122</a></td>
-<td>񀳑</td>
-<td></td>
+<td class="signwriting">񀳑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -676,8 +702,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00111.html">S1ee</a></td>
-<td>񅥑</td>
-<td></td>
+<td class="signwriting">񅥑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -685,8 +711,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00275.html">S1f1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -694,8 +720,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00273.html">S1ec</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -703,8 +729,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00089.html">S171</a></td>
-<td>񂩱</td>
-<td></td>
+<td class="signwriting">񂩱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -712,8 +738,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00121.html">S128</a></td>
-<td>񀼑</td>
-<td></td>
+<td class="signwriting">񀼑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -721,8 +747,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00162.html">S10b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -730,8 +756,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00127.html">S173</a></td>
-<td>񂬱</td>
-<td></td>
+<td class="signwriting">񂬱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -739,8 +765,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00164.html">S14d</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -748,8 +774,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00097.html">S145</a></td>
-<td>񁧱</td>
-<td></td>
+<td class="signwriting">񁧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -757,8 +783,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00143.html">S1ba</a></td>
-<td>񄗁</td>
-<td></td>
+<td class="signwriting">񄗁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -766,8 +792,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00224.html">S178</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -775,8 +801,8 @@
 <td>4finSpread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00137.html">S155</a></td>
-<td>񁿱</td>
-<td></td>
+<td class="signwriting">񁿱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -784,8 +810,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00167.html">S1cd</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -793,8 +819,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00061.html">S121</a></td>
-<td>񀱱</td>
-<td></td>
+<td class="signwriting">񀱱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -802,8 +828,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00154.html">S1c3</a></td>
-<td>񄤱</td>
-<td></td>
+<td class="signwriting">񄤱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -811,8 +837,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00228.html">S17f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -820,8 +846,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00152.html">S1da</a></td>
-<td>񅇑</td>
-<td></td>
+<td class="signwriting">񅇑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -829,8 +855,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00095.html">S158</a></td>
-<td>񂄑</td>
-<td></td>
+<td class="signwriting">񂄑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -838,8 +864,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00005.html">S1f9</a></td>
-<td>񅵱</td>
-<td></td>
+<td class="signwriting">񅵱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -847,8 +873,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00130.html">S17c</a></td>
-<td>񂺑</td>
-<td></td>
+<td class="signwriting">񂺑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -856,8 +882,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00094.html">S146</a></td>
-<td>񁩑</td>
-<td></td>
+<td class="signwriting">񁩑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -865,8 +891,8 @@
 <td>4finNonspread</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00133.html">S160</a></td>
-<td>񂐑</td>
-<td></td>
+<td class="signwriting">񂐑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -874,8 +900,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00241.html">S19d</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -883,8 +909,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00181.html">S11f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -892,8 +918,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00146.html">S1d0</a></td>
-<td>񄸑</td>
-<td></td>
+<td class="signwriting">񄸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -901,8 +927,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00205.html">S156</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -910,8 +936,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00216.html">S167</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -919,8 +945,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00087.html">S16e</a></td>
-<td>񂥑</td>
-<td></td>
+<td class="signwriting">񂥑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -928,8 +954,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00024.html">S1e0</a></td>
-<td>񅐁</td>
-<td>񅐑</td>
+<td class="signwriting">񅐁</td>
+<td class="signwriting">񅐑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -937,8 +963,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00206.html">S15b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -946,8 +972,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00150.html">S18c</a></td>
-<td>񃒑</td>
-<td></td>
+<td class="signwriting">񃒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -955,8 +981,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00219.html">S16b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -964,8 +990,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00223.html">S175</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -973,8 +999,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00115.html">S13d</a></td>
-<td>񁛡</td>
-<td>񁛱</td>
+<td class="signwriting">񁛡</td>
+<td class="signwriting">񁛱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -982,8 +1008,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00194.html">S138</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -991,8 +1017,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00140.html">S18b</a></td>
-<td>񃐱</td>
-<td></td>
+<td class="signwriting">񃐱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1000,8 +1026,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00208.html">S15e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1009,8 +1035,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00174.html">S10f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1018,8 +1044,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00271.html">S1e6</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1027,8 +1053,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00096.html">S159</a></td>
-<td>񂅱</td>
-<td></td>
+<td class="signwriting">񂅱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1036,8 +1062,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00215.html">S166</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1045,8 +1071,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00105.html">S1e5</a></td>
-<td>񅗱</td>
-<td></td>
+<td class="signwriting">񅗱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1054,8 +1080,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00114.html">S129</a></td>
-<td>񀽱</td>
-<td></td>
+<td class="signwriting">񀽱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1063,8 +1089,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00225.html">S179</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1072,8 +1098,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00240.html">S19b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1081,8 +1107,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00058.html">S112</a></td>
-<td>񀛑</td>
-<td></td>
+<td class="signwriting">񀛑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1090,8 +1116,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00260.html">S1c0</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1099,8 +1125,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00212.html">S163</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1108,8 +1134,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00025.html">S10c</a></td>
-<td>񀒑</td>
-<td></td>
+<td class="signwriting">񀒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1117,8 +1143,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00003.html">S1f8</a></td>
-<td>񅴑</td>
-<td></td>
+<td class="signwriting">񅴑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1126,8 +1152,8 @@
 <td>3_spread</td>
 <td>bent</td>
 <td><a href="../segments/seg00076.html">S190</a></td>
-<td>񃘑</td>
-<td></td>
+<td class="signwriting">񃘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1135,8 +1161,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00214.html">S165</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1144,8 +1170,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00022.html">S1de</a></td>
-<td>񅍑</td>
-<td></td>
+<td class="signwriting">񅍑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1153,8 +1179,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00019.html">S1ae</a></td>
-<td>񄅑</td>
-<td></td>
+<td class="signwriting">񄅑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1162,8 +1188,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00184.html">S12c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1171,8 +1197,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00246.html">S1a8</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1180,8 +1206,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00189.html">S133</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1189,8 +1215,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00183.html">S124</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1198,8 +1224,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00257.html">S1bd</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1207,8 +1233,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00267.html">S1cf</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1216,8 +1242,8 @@
 <td>3_spread</td>
 <td>extended</td>
 <td><a href="../segments/seg00074.html">S1c4</a></td>
-<td>񄦑</td>
-<td></td>
+<td class="signwriting">񄦑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1225,8 +1251,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00176.html">S113</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1234,8 +1260,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00141.html">S1a4</a></td>
-<td>񃶁</td>
-<td></td>
+<td class="signwriting">񃶁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1243,8 +1269,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00211.html">S162</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1252,8 +1278,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00227.html">S17b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1261,8 +1287,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00202.html">S14f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1270,8 +1296,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00264.html">S1c9</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1279,8 +1305,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00026.html">S1f2</a></td>
-<td>񅫁</td>
-<td></td>
+<td class="signwriting">񅫁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1288,8 +1314,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00190.html">S134</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1297,8 +1323,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00157.html">S1d3</a></td>
-<td>񄼱</td>
-<td></td>
+<td class="signwriting">񄼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1306,8 +1332,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00156.html">S1d2</a></td>
-<td>񄻑</td>
-<td></td>
+<td class="signwriting">񄻑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1315,8 +1341,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00230.html">S183</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1324,8 +1350,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00173.html">S10d</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1333,8 +1359,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00270.html">S1e3</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1342,8 +1368,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00261.html">S1c2</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1351,8 +1377,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00122.html">S12a</a></td>
-<td>񀿑</td>
-<td></td>
+<td class="signwriting">񀿑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1360,8 +1386,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00057.html">S1cb</a></td>
-<td>񄰱</td>
-<td></td>
+<td class="signwriting">񄰱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1369,8 +1395,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00007.html">S1fc</a></td>
-<td>񅺡</td>
-<td>񅺑</td>
+<td class="signwriting">񅺡</td>
+<td class="signwriting">񅺑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1378,8 +1404,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00014.html">S103</a></td>
-<td>񀄱</td>
-<td></td>
+<td class="signwriting">񀄱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1387,8 +1413,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00276.html">S1f6</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1396,8 +1422,8 @@
 <td>3_spread</td>
 <td>extended</td>
 <td><a href="../segments/seg00073.html">S1ab</a></td>
-<td>񄀱</td>
-<td></td>
+<td class="signwriting">񄀱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1405,8 +1431,8 @@
 <td>3_nonspread</td>
 <td>extended</td>
 <td><a href="../segments/seg00066.html">S18e</a></td>
-<td>񃕑</td>
-<td></td>
+<td class="signwriting">񃕑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1414,8 +1440,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00032.html">S1e2</a></td>
-<td>񅓁</td>
-<td></td>
+<td class="signwriting">񅓁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1423,8 +1449,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00191.html">S135</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1432,8 +1458,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00209.html">S15f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1441,8 +1467,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00106.html">S1e7</a></td>
-<td>񅚱</td>
-<td></td>
+<td class="signwriting">񅚱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1450,8 +1476,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00268.html">S1d9</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1459,8 +1485,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00038.html">S1b5</a></td>
-<td>񄏱</td>
-<td></td>
+<td class="signwriting">񄏱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1468,8 +1494,8 @@
 <td>1fin_othersNonfist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00160.html">S105</a></td>
-<td>񀇱</td>
-<td></td>
+<td class="signwriting">񀇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1477,8 +1503,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00041.html">S13e</a></td>
-<td>񁝑</td>
-<td></td>
+<td class="signwriting">񁝑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1486,8 +1512,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00059.html">S123</a></td>
-<td>񀴱</td>
-<td></td>
+<td class="signwriting">񀴱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1495,8 +1521,8 @@
 <td>2finNonspread_othersFist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00119.html">S1b2</a></td>
-<td>񄋑</td>
-<td></td>
+<td class="signwriting">񄋑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1504,8 +1530,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00256.html">S1bc</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1513,8 +1539,8 @@
 <td>2finNonspread_othersFist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00118.html">S1a3</a></td>
-<td>񃴱</td>
-<td></td>
+<td class="signwriting">񃴱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1522,8 +1548,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00226.html">S17a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1531,8 +1557,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00221.html">S172</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1540,8 +1566,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00237.html">S194</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1549,8 +1575,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00027.html">S1f3</a></td>
-<td>񅬱</td>
-<td></td>
+<td class="signwriting">񅬱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1558,8 +1584,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00243.html">S1a1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1567,8 +1593,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00020.html">S1c6</a></td>
-<td>񄩁</td>
-<td>񄩑</td>
+<td class="signwriting">񄩁</td>
+<td class="signwriting">񄩑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1576,8 +1602,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00055.html">S1b0</a></td>
-<td>񄈑</td>
-<td></td>
+<td class="signwriting">񄈑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1585,8 +1611,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00177.html">S114</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1594,8 +1620,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00102.html">S1a7</a></td>
-<td>񃺱</td>
-<td></td>
+<td class="signwriting">񃺱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1603,8 +1629,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00009.html">S1ff</a></td>
-<td>񅾱</td>
-<td></td>
+<td class="signwriting">񅾱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1612,8 +1638,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00030.html">S198</a></td>
-<td>񃤑</td>
-<td></td>
+<td class="signwriting">񃤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1621,8 +1647,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00233.html">S188</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1630,8 +1656,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00179.html">S11b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1639,8 +1665,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00247.html">S1a9</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1648,8 +1674,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00148.html">S1d6</a></td>
-<td>񅁑</td>
-<td></td>
+<td class="signwriting">񅁑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1657,8 +1683,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00222.html">S174</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1666,8 +1692,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00048.html">S11d</a></td>
-<td>񀫡</td>
-<td></td>
+<td class="signwriting">񀫡</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1675,8 +1701,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00008.html">S1fd</a></td>
-<td>񅼁</td>
-<td>񅻱</td>
+<td class="signwriting">񅼁</td>
+<td class="signwriting">񅻱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1684,8 +1710,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00266.html">S1cc</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00024.html
+++ b/inventories/inv00024.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>LSQ (SP_47)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>LSQ (SP_47)</h1>
@@ -55,8 +81,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00083.html">S180</a></td>
-<td>񃀑</td>
-<td>񃀁</td>
+<td class="signwriting">񃀑</td>
+<td class="signwriting">񃀁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00087.html">S16e</a></td>
-<td>񂥑</td>
-<td></td>
+<td class="signwriting">񂥑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00101.html">S157</a></td>
-<td>񂂱</td>
-<td></td>
+<td class="signwriting">񂂱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00158.html">S1d4</a></td>
-<td>񄾑</td>
-<td></td>
+<td class="signwriting">񄾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00003.html">S1f8</a></td>
-<td>񅴑</td>
-<td></td>
+<td class="signwriting">񅴑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00103.html">S1c5</a></td>
-<td>񄧱</td>
-<td></td>
+<td class="signwriting">񄧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00098.html">S14e</a></td>
-<td>񁵑</td>
-<td></td>
+<td class="signwriting">񁵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00113.html">S1f4</a></td>
-<td>񅮁</td>
-<td>񅮑</td>
+<td class="signwriting">񅮁</td>
+<td class="signwriting">񅮑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00095.html">S158</a></td>
-<td>񂄑</td>
-<td></td>
+<td class="signwriting">񂄑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00043.html">S118</a></td>
-<td>񀤑</td>
-<td></td>
+<td class="signwriting">񀤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00272.html">S1e8</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00163.html">S14a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00134.html">S153</a></td>
-<td>񁼱</td>
-<td></td>
+<td class="signwriting">񁼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00108.html">S1ed</a></td>
-<td>񅣡</td>
-<td>񅢑</td>
+<td class="signwriting">񅣡</td>
+<td class="signwriting">񅢑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00131.html">S17d</a></td>
-<td>񂻱</td>
-<td></td>
+<td class="signwriting">񂻱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00220.html">S16c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00082.html">S14b</a></td>
-<td>񁰱</td>
-<td></td>
+<td class="signwriting">񁰱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -460,8 +486,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00155.html">S1d1</a></td>
-<td>񄹱</td>
-<td></td>
+<td class="signwriting">񄹱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -469,8 +495,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00275.html">S1f1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -478,8 +504,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00267.html">S1cf</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -487,8 +513,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00039.html">S119</a></td>
-<td>񀥱</td>
-<td></td>
+<td class="signwriting">񀥱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -496,8 +522,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00165.html">S16f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -505,8 +531,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00144.html">S1bb</a></td>
-<td>񄘱</td>
-<td></td>
+<td class="signwriting">񄘱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -514,8 +540,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00054.html">S1a0</a></td>
-<td>񃰑</td>
-<td></td>
+<td class="signwriting">񃰑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -523,8 +549,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00006.html">S1fb</a></td>
-<td>񅸱</td>
-<td></td>
+<td class="signwriting">񅸱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -532,8 +558,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00031.html">S1e1</a></td>
-<td>񅑱</td>
-<td>񅑡</td>
+<td class="signwriting">񅑱</td>
+<td class="signwriting">񅑡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -541,8 +567,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00273.html">S1ec</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -550,8 +576,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00139.html">S187</a></td>
-<td>񃊱</td>
-<td></td>
+<td class="signwriting">񃊱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -559,8 +585,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00226.html">S17a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -568,8 +594,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00146.html">S1d0</a></td>
-<td>񄸑</td>
-<td></td>
+<td class="signwriting">񄸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -577,8 +603,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00166.html">S17e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -586,8 +612,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00097.html">S145</a></td>
-<td>񁧱</td>
-<td></td>
+<td class="signwriting">񁧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -595,8 +621,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00025.html">S10c</a></td>
-<td>񀒑</td>
-<td></td>
+<td class="signwriting">񀒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -604,8 +630,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00062.html">S122</a></td>
-<td>񀳑</td>
-<td></td>
+<td class="signwriting">񀳑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -613,8 +639,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00053.html">S19c</a></td>
-<td>񃪑</td>
-<td></td>
+<td class="signwriting">񃪑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -622,8 +648,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00135.html">S154</a></td>
-<td>񁾑</td>
-<td></td>
+<td class="signwriting">񁾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -631,8 +657,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00121.html">S128</a></td>
-<td>񀼑</td>
-<td></td>
+<td class="signwriting">񀼑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -640,8 +666,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00222.html">S174</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -649,8 +675,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -658,8 +684,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00228.html">S17f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -667,8 +693,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00224.html">S178</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -676,8 +702,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00040.html">S132</a></td>
-<td>񁋑</td>
-<td></td>
+<td class="signwriting">񁋑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -685,8 +711,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00065.html">S142</a></td>
-<td>񁣑</td>
-<td></td>
+<td class="signwriting">񁣑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -694,8 +720,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00229.html">S181</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -703,8 +729,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00204.html">S152</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -712,8 +738,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00142.html">S1a5</a></td>
-<td>񃷱</td>
-<td></td>
+<td class="signwriting">񃷱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -721,8 +747,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00111.html">S1ee</a></td>
-<td>񅥑</td>
-<td></td>
+<td class="signwriting">񅥑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -730,8 +756,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00260.html">S1c0</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -739,8 +765,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00122.html">S12a</a></td>
-<td>񀿑</td>
-<td></td>
+<td class="signwriting">񀿑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -748,8 +774,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00116.html">S13f</a></td>
-<td>񁞱</td>
-<td></td>
+<td class="signwriting">񁞱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -757,8 +783,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00130.html">S17c</a></td>
-<td>񂺑</td>
-<td></td>
+<td class="signwriting">񂺑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -766,8 +792,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00032.html">S1e2</a></td>
-<td>񅓁</td>
-<td></td>
+<td class="signwriting">񅓁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -775,8 +801,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00115.html">S13d</a></td>
-<td>񁛡</td>
-<td>񁛱</td>
+<td class="signwriting">񁛡</td>
+<td class="signwriting">񁛱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -784,8 +810,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00106.html">S1e7</a></td>
-<td>񅚱</td>
-<td></td>
+<td class="signwriting">񅚱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -793,8 +819,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00271.html">S1e6</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -802,8 +828,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -811,8 +837,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00088.html">S170</a></td>
-<td>񂨑</td>
-<td></td>
+<td class="signwriting">񂨑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -820,8 +846,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00022.html">S1de</a></td>
-<td>񅍑</td>
-<td></td>
+<td class="signwriting">񅍑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -829,8 +855,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -838,8 +864,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00227.html">S17b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -847,8 +873,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00232.html">S186</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -856,8 +882,8 @@
 <td>4finSpread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00137.html">S155</a></td>
-<td>񁿱</td>
-<td></td>
+<td class="signwriting">񁿱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -865,8 +891,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00216.html">S167</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -874,8 +900,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00026.html">S1f2</a></td>
-<td>񅫁</td>
-<td></td>
+<td class="signwriting">񅫁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -883,8 +909,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00274.html">S1ef</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -892,8 +918,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00256.html">S1bc</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -901,8 +927,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00114.html">S129</a></td>
-<td>񀽱</td>
-<td></td>
+<td class="signwriting">񀽱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -910,8 +936,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00189.html">S133</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -919,8 +945,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00061.html">S121</a></td>
-<td>񀱱</td>
-<td></td>
+<td class="signwriting">񀱱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -928,8 +954,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00162.html">S10b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -937,8 +963,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00218.html">S16a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -946,8 +972,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00151.html">S18d</a></td>
-<td>񃓱</td>
-<td></td>
+<td class="signwriting">񃓱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -955,8 +981,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00030.html">S198</a></td>
-<td>񃤑</td>
-<td></td>
+<td class="signwriting">񃤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -964,8 +990,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00153.html">S1c1</a></td>
-<td>񄡱</td>
-<td></td>
+<td class="signwriting">񄡱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -973,8 +999,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00177.html">S114</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -982,8 +1008,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00215.html">S166</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -991,8 +1017,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00176.html">S113</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1000,8 +1026,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00223.html">S175</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1009,8 +1035,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00221.html">S172</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1018,8 +1044,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00183.html">S124</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1027,8 +1053,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00205.html">S156</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1036,8 +1062,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00086.html">S168</a></td>
-<td>񂜑</td>
-<td></td>
+<td class="signwriting">񂜑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1045,8 +1071,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00089.html">S171</a></td>
-<td>񂩱</td>
-<td></td>
+<td class="signwriting">񂩱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1054,8 +1080,8 @@
 <td>4finNonspread</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00133.html">S160</a></td>
-<td>񂐑</td>
-<td></td>
+<td class="signwriting">񂐑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1063,8 +1089,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00154.html">S1c3</a></td>
-<td>񄤱</td>
-<td></td>
+<td class="signwriting">񄤱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1072,8 +1098,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00217.html">S169</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1081,8 +1107,8 @@
 <td>3_spread</td>
 <td>extended</td>
 <td><a href="../segments/seg00074.html">S1c4</a></td>
-<td>񄦑</td>
-<td></td>
+<td class="signwriting">񄦑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1090,8 +1116,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00171.html">S107</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1099,8 +1125,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00123.html">S12b</a></td>
-<td>񁀱</td>
-<td></td>
+<td class="signwriting">񁀱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1108,8 +1134,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00059.html">S123</a></td>
-<td>񀴱</td>
-<td></td>
+<td class="signwriting">񀴱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1117,8 +1143,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00105.html">S1e5</a></td>
-<td>񅗱</td>
-<td></td>
+<td class="signwriting">񅗱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1126,8 +1152,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00058.html">S112</a></td>
-<td>񀛑</td>
-<td></td>
+<td class="signwriting">񀛑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1135,8 +1161,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00127.html">S173</a></td>
-<td>񂬱</td>
-<td></td>
+<td class="signwriting">񂬱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1144,8 +1170,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00212.html">S163</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1153,8 +1179,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00094.html">S146</a></td>
-<td>񁩑</td>
-<td></td>
+<td class="signwriting">񁩑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1162,8 +1188,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00005.html">S1f9</a></td>
-<td>񅵱</td>
-<td></td>
+<td class="signwriting">񅵱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1171,8 +1197,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00270.html">S1e3</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1180,8 +1206,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00140.html">S18b</a></td>
-<td>񃐱</td>
-<td></td>
+<td class="signwriting">񃐱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1189,8 +1215,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00219.html">S16b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1198,8 +1224,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00023.html">S1df</a></td>
-<td>񅎱</td>
-<td></td>
+<td class="signwriting">񅎱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1207,8 +1233,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00167.html">S1cd</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1216,8 +1242,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00225.html">S179</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1225,8 +1251,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00277.html">S1fa</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1234,8 +1260,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00024.html">S1e0</a></td>
-<td>񅐁</td>
-<td>񅐑</td>
+<td class="signwriting">񅐁</td>
+<td class="signwriting">񅐑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1243,8 +1269,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00236.html">S191</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1252,8 +1278,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00240.html">S19b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1261,8 +1287,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00110.html">S1e4</a></td>
-<td>񅖑</td>
-<td></td>
+<td class="signwriting">񅖑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1270,8 +1296,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00248.html">S1aa</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1279,8 +1305,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00190.html">S134</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1288,8 +1314,8 @@
 <td>2finNonspread_othersFist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00118.html">S1a3</a></td>
-<td>񃴱</td>
-<td></td>
+<td class="signwriting">񃴱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1297,8 +1323,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00143.html">S1ba</a></td>
-<td>񄗁</td>
-<td></td>
+<td class="signwriting">񄗁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1306,8 +1332,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00156.html">S1d2</a></td>
-<td>񄻑</td>
-<td></td>
+<td class="signwriting">񄻑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1315,8 +1341,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00141.html">S1a4</a></td>
-<td>񃶁</td>
-<td></td>
+<td class="signwriting">񃶁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1324,8 +1350,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00203.html">S151</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1333,8 +1359,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00152.html">S1da</a></td>
-<td>񅇑</td>
-<td></td>
+<td class="signwriting">񅇑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1342,8 +1368,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00150.html">S18c</a></td>
-<td>񃒑</td>
-<td></td>
+<td class="signwriting">񃒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1351,8 +1377,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00184.html">S12c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1360,8 +1386,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00027.html">S1f3</a></td>
-<td>񅬱</td>
-<td></td>
+<td class="signwriting">񅬱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1369,8 +1395,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00278.html">S1fe</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1378,8 +1404,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00185.html">S12e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1387,8 +1413,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00241.html">S19d</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1396,8 +1422,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00245.html">S1a6</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1405,8 +1431,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00233.html">S188</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1414,8 +1440,8 @@
 <td>1fin_othersNonfist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00160.html">S105</a></td>
-<td>񀇱</td>
-<td></td>
+<td class="signwriting">񀇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1423,8 +1449,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00170.html">S104</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1432,8 +1458,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00014.html">S103</a></td>
-<td>񀄱</td>
-<td></td>
+<td class="signwriting">񀄱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1441,8 +1467,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00015.html">S108</a></td>
-<td>񀌑</td>
-<td></td>
+<td class="signwriting">񀌑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1450,8 +1476,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00169.html">S102</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1459,8 +1485,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00173.html">S10d</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1468,8 +1494,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00206.html">S15b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1477,8 +1503,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00195.html">S139</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00025.html
+++ b/inventories/inv00025.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>DSGS (SP_48)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>DSGS (SP_48)</h1>
@@ -55,8 +81,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00134.html">S153</a></td>
-<td>񁼱</td>
-<td></td>
+<td class="signwriting">񁼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00113.html">S1f4</a></td>
-<td>񅮁</td>
-<td>񅮑</td>
+<td class="signwriting">񅮁</td>
+<td class="signwriting">񅮑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00043.html">S118</a></td>
-<td>񀤑</td>
-<td></td>
+<td class="signwriting">񀤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00108.html">S1ed</a></td>
-<td>񅣡</td>
-<td>񅢑</td>
+<td class="signwriting">񅣡</td>
+<td class="signwriting">񅢑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00131.html">S17d</a></td>
-<td>񂻱</td>
-<td></td>
+<td class="signwriting">񂻱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00165.html">S16f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00273.html">S1ec</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00031.html">S1e1</a></td>
-<td>񅑱</td>
-<td>񅑡</td>
+<td class="signwriting">񅑱</td>
+<td class="signwriting">񅑡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00083.html">S180</a></td>
-<td>񃀑</td>
-<td>񃀁</td>
+<td class="signwriting">񃀑</td>
+<td class="signwriting">񃀁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00158.html">S1d4</a></td>
-<td>񄾑</td>
-<td></td>
+<td class="signwriting">񄾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00098.html">S14e</a></td>
-<td>񁵑</td>
-<td></td>
+<td class="signwriting">񁵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00111.html">S1ee</a></td>
-<td>񅥑</td>
-<td></td>
+<td class="signwriting">񅥑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00101.html">S157</a></td>
-<td>񂂱</td>
-<td></td>
+<td class="signwriting">񂂱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00274.html">S1ef</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00204.html">S152</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00089.html">S171</a></td>
-<td>񂩱</td>
-<td></td>
+<td class="signwriting">񂩱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00103.html">S1c5</a></td>
-<td>񄧱</td>
-<td></td>
+<td class="signwriting">񄧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00224.html">S178</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td>4finNonspread</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00133.html">S160</a></td>
-<td>񂐑</td>
-<td></td>
+<td class="signwriting">񂐑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00139.html">S187</a></td>
-<td>񃊱</td>
-<td></td>
+<td class="signwriting">񃊱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -460,8 +486,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00166.html">S17e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -469,8 +495,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -478,8 +504,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00006.html">S1fb</a></td>
-<td>񅸱</td>
-<td></td>
+<td class="signwriting">񅸱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -487,8 +513,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00121.html">S128</a></td>
-<td>񀼑</td>
-<td></td>
+<td class="signwriting">񀼑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -496,8 +522,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -505,8 +531,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -514,8 +540,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00116.html">S13f</a></td>
-<td>񁞱</td>
-<td></td>
+<td class="signwriting">񁞱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -523,8 +549,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00155.html">S1d1</a></td>
-<td>񄹱</td>
-<td></td>
+<td class="signwriting">񄹱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -532,8 +558,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00227.html">S17b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -541,8 +567,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -550,8 +576,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00174.html">S10f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -559,8 +585,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00267.html">S1cf</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -568,8 +594,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00130.html">S17c</a></td>
-<td>񂺑</td>
-<td></td>
+<td class="signwriting">񂺑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -577,8 +603,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -586,8 +612,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00114.html">S129</a></td>
-<td>񀽱</td>
-<td></td>
+<td class="signwriting">񀽱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -595,8 +621,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -604,8 +630,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00054.html">S1a0</a></td>
-<td>񃰑</td>
-<td></td>
+<td class="signwriting">񃰑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -613,8 +639,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00115.html">S13d</a></td>
-<td>񁛡</td>
-<td>񁛱</td>
+<td class="signwriting">񁛡</td>
+<td class="signwriting">񁛱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -622,8 +648,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00277.html">S1fa</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -631,8 +657,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00135.html">S154</a></td>
-<td>񁾑</td>
-<td></td>
+<td class="signwriting">񁾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -640,8 +666,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00053.html">S19c</a></td>
-<td>񃪑</td>
-<td></td>
+<td class="signwriting">񃪑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -649,8 +675,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00022.html">S1de</a></td>
-<td>񅍑</td>
-<td></td>
+<td class="signwriting">񅍑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -658,8 +684,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00039.html">S119</a></td>
-<td>񀥱</td>
-<td></td>
+<td class="signwriting">񀥱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -667,8 +693,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00151.html">S18d</a></td>
-<td>񃓱</td>
-<td></td>
+<td class="signwriting">񃓱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -676,8 +702,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00275.html">S1f1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -685,8 +711,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00163.html">S14a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -694,8 +720,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00147.html">S1d5</a></td>
-<td>񄿱</td>
-<td></td>
+<td class="signwriting">񄿱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -703,8 +729,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00215.html">S166</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -712,8 +738,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00105.html">S1e5</a></td>
-<td>񅗱</td>
-<td></td>
+<td class="signwriting">񅗱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -721,8 +747,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00065.html">S142</a></td>
-<td>񁣑</td>
-<td></td>
+<td class="signwriting">񁣑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -730,8 +756,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00246.html">S1a8</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -739,8 +765,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00229.html">S181</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -748,8 +774,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00088.html">S170</a></td>
-<td>񂨑</td>
-<td></td>
+<td class="signwriting">񂨑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -757,8 +783,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00086.html">S168</a></td>
-<td>񂜑</td>
-<td></td>
+<td class="signwriting">񂜑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -766,8 +792,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00003.html">S1f8</a></td>
-<td>񅴑</td>
-<td></td>
+<td class="signwriting">񅴑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -775,8 +801,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00146.html">S1d0</a></td>
-<td>񄸑</td>
-<td></td>
+<td class="signwriting">񄸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -784,8 +810,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00241.html">S19d</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -793,8 +819,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00220.html">S16c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -802,8 +828,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00232.html">S186</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -811,8 +837,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00148.html">S1d6</a></td>
-<td>񅁑</td>
-<td></td>
+<td class="signwriting">񅁑</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00026.html
+++ b/inventories/inv00026.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>LSF-SR (SP_49)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>LSF-SR (SP_49)</h1>
@@ -55,8 +81,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00083.html">S180</a></td>
-<td>񃀑</td>
-<td>񃀁</td>
+<td class="signwriting">񃀑</td>
+<td class="signwriting">񃀁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00273.html">S1ec</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00158.html">S1d4</a></td>
-<td>񄾑</td>
-<td></td>
+<td class="signwriting">񄾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00043.html">S118</a></td>
-<td>񀤑</td>
-<td></td>
+<td class="signwriting">񀤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00220.html">S16c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00134.html">S153</a></td>
-<td>񁼱</td>
-<td></td>
+<td class="signwriting">񁼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00108.html">S1ed</a></td>
-<td>񅣡</td>
-<td>񅢑</td>
+<td class="signwriting">񅣡</td>
+<td class="signwriting">񅢑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00098.html">S14e</a></td>
-<td>񁵑</td>
-<td></td>
+<td class="signwriting">񁵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00113.html">S1f4</a></td>
-<td>񅮁</td>
-<td>񅮑</td>
+<td class="signwriting">񅮁</td>
+<td class="signwriting">񅮑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00103.html">S1c5</a></td>
-<td>񄧱</td>
-<td></td>
+<td class="signwriting">񄧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00054.html">S1a0</a></td>
-<td>񃰑</td>
-<td></td>
+<td class="signwriting">񃰑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00121.html">S128</a></td>
-<td>񀼑</td>
-<td></td>
+<td class="signwriting">񀼑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00204.html">S152</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00101.html">S157</a></td>
-<td>񂂱</td>
-<td></td>
+<td class="signwriting">񂂱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00229.html">S181</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00116.html">S13f</a></td>
-<td>񁞱</td>
-<td></td>
+<td class="signwriting">񁞱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00039.html">S119</a></td>
-<td>񀥱</td>
-<td></td>
+<td class="signwriting">񀥱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00115.html">S13d</a></td>
-<td>񁛡</td>
-<td>񁛱</td>
+<td class="signwriting">񁛡</td>
+<td class="signwriting">񁛱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -460,8 +486,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00131.html">S17d</a></td>
-<td>񂻱</td>
-<td></td>
+<td class="signwriting">񂻱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -469,8 +495,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00114.html">S129</a></td>
-<td>񀽱</td>
-<td></td>
+<td class="signwriting">񀽱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -478,8 +504,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00166.html">S17e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -487,8 +513,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00228.html">S17f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -496,8 +522,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00155.html">S1d1</a></td>
-<td>񄹱</td>
-<td></td>
+<td class="signwriting">񄹱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -505,8 +531,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00135.html">S154</a></td>
-<td>񁾑</td>
-<td></td>
+<td class="signwriting">񁾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -514,8 +540,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00275.html">S1f1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -523,8 +549,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -532,8 +558,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -541,8 +567,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00156.html">S1d2</a></td>
-<td>񄻑</td>
-<td></td>
+<td class="signwriting">񄻑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -550,8 +576,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00130.html">S17c</a></td>
-<td>񂺑</td>
-<td></td>
+<td class="signwriting">񂺑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -559,8 +585,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00163.html">S14a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -568,8 +594,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00162.html">S10b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -577,8 +603,8 @@
 <td>4finNonspread</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00133.html">S160</a></td>
-<td>񂐑</td>
-<td></td>
+<td class="signwriting">񂐑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -586,8 +612,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -595,8 +621,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00232.html">S186</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -604,8 +630,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00127.html">S173</a></td>
-<td>񂬱</td>
-<td></td>
+<td class="signwriting">񂬱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -613,8 +639,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00003.html">S1f8</a></td>
-<td>񅴑</td>
-<td></td>
+<td class="signwriting">񅴑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -622,8 +648,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00111.html">S1ee</a></td>
-<td>񅥑</td>
-<td></td>
+<td class="signwriting">񅥑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -631,8 +657,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00031.html">S1e1</a></td>
-<td>񅑱</td>
-<td>񅑡</td>
+<td class="signwriting">񅑱</td>
+<td class="signwriting">񅑡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -640,8 +666,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00082.html">S14b</a></td>
-<td>񁰱</td>
-<td></td>
+<td class="signwriting">񁰱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -649,8 +675,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00151.html">S18d</a></td>
-<td>񃓱</td>
-<td></td>
+<td class="signwriting">񃓱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -658,8 +684,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -667,8 +693,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00097.html">S145</a></td>
-<td>񁧱</td>
-<td></td>
+<td class="signwriting">񁧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -676,8 +702,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00026.html">S1f2</a></td>
-<td>񅫁</td>
-<td></td>
+<td class="signwriting">񅫁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -685,8 +711,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00267.html">S1cf</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -694,8 +720,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00208.html">S15e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -703,8 +729,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00224.html">S178</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -712,8 +738,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00025.html">S10c</a></td>
-<td>񀒑</td>
-<td></td>
+<td class="signwriting">񀒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -721,8 +747,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00146.html">S1d0</a></td>
-<td>񄸑</td>
-<td></td>
+<td class="signwriting">񄸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -730,8 +756,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00256.html">S1bc</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -739,8 +765,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00223.html">S175</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -748,8 +774,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00241.html">S19d</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -757,8 +783,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00165.html">S16f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -766,8 +792,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00040.html">S132</a></td>
-<td>񁋑</td>
-<td></td>
+<td class="signwriting">񁋑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -775,8 +801,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00123.html">S12b</a></td>
-<td>񁀱</td>
-<td></td>
+<td class="signwriting">񁀱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -784,8 +810,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00183.html">S124</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -793,8 +819,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00022.html">S1de</a></td>
-<td>񅍑</td>
-<td></td>
+<td class="signwriting">񅍑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -802,8 +828,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00065.html">S142</a></td>
-<td>񁣑</td>
-<td></td>
+<td class="signwriting">񁣑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -811,8 +837,8 @@
 <td>4finSpread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00137.html">S155</a></td>
-<td>񁿱</td>
-<td></td>
+<td class="signwriting">񁿱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -820,8 +846,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00095.html">S158</a></td>
-<td>񂄑</td>
-<td></td>
+<td class="signwriting">񂄑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -829,8 +855,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00089.html">S171</a></td>
-<td>񂩱</td>
-<td></td>
+<td class="signwriting">񂩱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -838,8 +864,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00152.html">S1da</a></td>
-<td>񅇑</td>
-<td></td>
+<td class="signwriting">񅇑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -847,8 +873,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00144.html">S1bb</a></td>
-<td>񄘱</td>
-<td></td>
+<td class="signwriting">񄘱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -856,8 +882,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00230.html">S183</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -865,8 +891,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00277.html">S1fa</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -874,8 +900,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00053.html">S19c</a></td>
-<td>񃪑</td>
-<td></td>
+<td class="signwriting">񃪑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -883,8 +909,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00086.html">S168</a></td>
-<td>񂜑</td>
-<td></td>
+<td class="signwriting">񂜑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -892,8 +918,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00139.html">S187</a></td>
-<td>񃊱</td>
-<td></td>
+<td class="signwriting">񃊱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -901,8 +927,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00205.html">S156</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -910,8 +936,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00088.html">S170</a></td>
-<td>񂨑</td>
-<td></td>
+<td class="signwriting">񂨑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -919,8 +945,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00059.html">S123</a></td>
-<td>񀴱</td>
-<td></td>
+<td class="signwriting">񀴱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -928,8 +954,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00174.html">S10f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -937,8 +963,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00274.html">S1ef</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -946,8 +972,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00216.html">S167</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -955,8 +981,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00094.html">S146</a></td>
-<td>񁩑</td>
-<td></td>
+<td class="signwriting">񁩑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -964,8 +990,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00207.html">S15c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -973,8 +999,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00062.html">S122</a></td>
-<td>񀳑</td>
-<td></td>
+<td class="signwriting">񀳑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -982,8 +1008,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00005.html">S1f9</a></td>
-<td>񅵱</td>
-<td></td>
+<td class="signwriting">񅵱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -991,8 +1017,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00271.html">S1e6</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1000,8 +1026,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00222.html">S174</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1009,8 +1035,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00225.html">S179</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1018,8 +1044,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00058.html">S112</a></td>
-<td>񀛑</td>
-<td></td>
+<td class="signwriting">񀛑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1027,8 +1053,8 @@
 <td>2finNonspread_othersFist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00118.html">S1a3</a></td>
-<td>񃴱</td>
-<td></td>
+<td class="signwriting">񃴱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1036,8 +1062,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00185.html">S12e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1045,8 +1071,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00106.html">S1e7</a></td>
-<td>񅚱</td>
-<td></td>
+<td class="signwriting">񅚱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1054,8 +1080,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00153.html">S1c1</a></td>
-<td>񄡱</td>
-<td></td>
+<td class="signwriting">񄡱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1063,8 +1089,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00085.html">S149</a></td>
-<td>񁭱</td>
-<td></td>
+<td class="signwriting">񁭱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1072,8 +1098,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00023.html">S1df</a></td>
-<td>񅎱</td>
-<td></td>
+<td class="signwriting">񅎱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1081,8 +1107,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00061.html">S121</a></td>
-<td>񀱱</td>
-<td></td>
+<td class="signwriting">񀱱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1090,8 +1116,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00276.html">S1f6</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1099,8 +1125,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00221.html">S172</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1108,8 +1134,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00157.html">S1d3</a></td>
-<td>񄼱</td>
-<td></td>
+<td class="signwriting">񄼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1117,8 +1143,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00150.html">S18c</a></td>
-<td>񃒑</td>
-<td></td>
+<td class="signwriting">񃒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1126,8 +1152,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00032.html">S1e2</a></td>
-<td>񅓁</td>
-<td></td>
+<td class="signwriting">񅓁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1135,8 +1161,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00147.html">S1d5</a></td>
-<td>񄿱</td>
-<td></td>
+<td class="signwriting">񄿱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1144,8 +1170,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00159.html">S1d8</a></td>
-<td>񅄑</td>
-<td></td>
+<td class="signwriting">񅄑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1153,8 +1179,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00270.html">S1e3</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1162,8 +1188,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00014.html">S103</a></td>
-<td>񀄱</td>
-<td></td>
+<td class="signwriting">񀄱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1171,8 +1197,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00202.html">S14f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1180,8 +1206,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00006.html">S1fb</a></td>
-<td>񅸱</td>
-<td></td>
+<td class="signwriting">񅸱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1189,8 +1215,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00212.html">S163</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1198,8 +1224,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00057.html">S1cb</a></td>
-<td>񄰱</td>
-<td></td>
+<td class="signwriting">񄰱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1207,8 +1233,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00226.html">S17a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1216,8 +1242,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00110.html">S1e4</a></td>
-<td>񅖑</td>
-<td></td>
+<td class="signwriting">񅖑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1225,8 +1251,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00215.html">S166</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1234,8 +1260,8 @@
 <td>3_nonspread</td>
 <td>extended</td>
 <td><a href="../segments/seg00066.html">S18e</a></td>
-<td>񃕑</td>
-<td></td>
+<td class="signwriting">񃕑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1243,8 +1269,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00030.html">S198</a></td>
-<td>񃤑</td>
-<td></td>
+<td class="signwriting">񃤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1252,8 +1278,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00020.html">S1c6</a></td>
-<td>񄩁</td>
-<td>񄩑</td>
+<td class="signwriting">񄩁</td>
+<td class="signwriting">񄩑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1261,8 +1287,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00171.html">S107</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1270,8 +1296,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00233.html">S188</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1279,8 +1305,8 @@
 <td>2finNonspread_othersFist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00119.html">S1b2</a></td>
-<td>񄋑</td>
-<td></td>
+<td class="signwriting">񄋑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1288,8 +1314,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00140.html">S18b</a></td>
-<td>񃐱</td>
-<td></td>
+<td class="signwriting">񃐱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1297,8 +1323,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00217.html">S169</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1306,8 +1332,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00124.html">S127</a></td>
-<td>񀺱</td>
-<td></td>
+<td class="signwriting">񀺱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1315,8 +1341,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00154.html">S1c3</a></td>
-<td>񄤱</td>
-<td></td>
+<td class="signwriting">񄤱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1324,8 +1350,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00234.html">S189</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1333,8 +1359,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00176.html">S113</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1342,8 +1368,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00141.html">S1a4</a></td>
-<td>񃶁</td>
-<td></td>
+<td class="signwriting">񃶁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1351,8 +1377,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00170.html">S104</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1360,8 +1386,8 @@
 <td>1fin_othersNonfist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00160.html">S105</a></td>
-<td>񀇱</td>
-<td></td>
+<td class="signwriting">񀇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1369,8 +1395,8 @@
 <td>3_spread</td>
 <td>extended</td>
 <td><a href="../segments/seg00074.html">S1c4</a></td>
-<td>񄦑</td>
-<td></td>
+<td class="signwriting">񄦑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1378,8 +1404,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00167.html">S1cd</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1387,8 +1413,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00211.html">S162</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00027.html
+++ b/inventories/inv00027.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>LIS-SI (SP_50)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>LIS-SI (SP_50)</h1>
@@ -55,8 +81,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00113.html">S1f4</a></td>
-<td>񅮁</td>
-<td>񅮑</td>
+<td class="signwriting">񅮁</td>
+<td class="signwriting">񅮑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00028.html
+++ b/inventories/inv00028.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>LSCh (SP_135)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>LSCh (SP_135)</h1>
@@ -55,8 +81,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>3_nonspread</td>
 <td>extended</td>
 <td><a href="../segments/seg00066.html">S18e</a></td>
-<td>񃕑</td>
-<td></td>
+<td class="signwriting">񃕑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00232.html">S186</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00097.html">S145</a></td>
-<td>񁧱</td>
-<td></td>
+<td class="signwriting">񁧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00140.html">S18b</a></td>
-<td>񃐱</td>
-<td></td>
+<td class="signwriting">񃐱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00062.html">S122</a></td>
-<td>񀳑</td>
-<td></td>
+<td class="signwriting">񀳑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00005.html">S1f9</a></td>
-<td>񅵱</td>
-<td></td>
+<td class="signwriting">񅵱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00032.html">S1e2</a></td>
-<td>񅓁</td>
-<td></td>
+<td class="signwriting">񅓁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00108.html">S1ed</a></td>
-<td>񅣡</td>
-<td>񅢑</td>
+<td class="signwriting">񅣡</td>
+<td class="signwriting">񅢑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00273.html">S1ec</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00274.html">S1ef</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00265.html">S1ca</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00178.html">S117</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00156.html">S1d2</a></td>
-<td>񄻑</td>
-<td></td>
+<td class="signwriting">񄻑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00144.html">S1bb</a></td>
-<td>񄘱</td>
-<td></td>
+<td class="signwriting">񄘱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00043.html">S118</a></td>
-<td>񀤑</td>
-<td></td>
+<td class="signwriting">񀤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00216.html">S167</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00029.html
+++ b/inventories/inv00029.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>CSL, ZGS (SP_83)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>CSL, ZGS (SP_83)</h1>
@@ -55,8 +81,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00232.html">S186</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00116.html">S13f</a></td>
-<td>񁞱</td>
-<td></td>
+<td class="signwriting">񁞱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00167.html">S1cd</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00251.html">S1b1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00007.html">S1fc</a></td>
-<td>񅺡</td>
-<td>񅺑</td>
+<td class="signwriting">񅺡</td>
+<td class="signwriting">񅺑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>4_nonspread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00091.html">S1d7</a></td>
-<td>񅂱</td>
-<td></td>
+<td class="signwriting">񅂱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00053.html">S19c</a></td>
-<td>񃪑</td>
-<td></td>
+<td class="signwriting">񃪑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00152.html">S1da</a></td>
-<td>񅇑</td>
-<td></td>
+<td class="signwriting">񅇑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00113.html">S1f4</a></td>
-<td>񅮁</td>
-<td>񅮑</td>
+<td class="signwriting">񅮁</td>
+<td class="signwriting">񅮑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00008.html">S1fd</a></td>
-<td>񅼁</td>
-<td>񅻱</td>
+<td class="signwriting">񅼁</td>
+<td class="signwriting">񅻱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00243.html">S1a1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00174.html">S10f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00166.html">S17e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00054.html">S1a0</a></td>
-<td>񃰑</td>
-<td></td>
+<td class="signwriting">񃰑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00141.html">S1a4</a></td>
-<td>񃶁</td>
-<td></td>
+<td class="signwriting">񃶁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00040.html">S132</a></td>
-<td>񁋑</td>
-<td></td>
+<td class="signwriting">񁋑</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00030.html
+++ b/inventories/inv00030.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>LSC (CO) (SP_51)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>LSC (CO) (SP_51)</h1>
@@ -55,8 +81,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00108.html">S1ed</a></td>
-<td>񅣡</td>
-<td>񅢑</td>
+<td class="signwriting">񅣡</td>
+<td class="signwriting">񅢑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00162.html">S10b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00083.html">S180</a></td>
-<td>񃀑</td>
-<td>񃀁</td>
+<td class="signwriting">񃀑</td>
+<td class="signwriting">񃀁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00098.html">S14e</a></td>
-<td>񁵑</td>
-<td></td>
+<td class="signwriting">񁵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00113.html">S1f4</a></td>
-<td>񅮁</td>
-<td>񅮑</td>
+<td class="signwriting">񅮁</td>
+<td class="signwriting">񅮑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00232.html">S186</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00103.html">S1c5</a></td>
-<td>񄧱</td>
-<td></td>
+<td class="signwriting">񄧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00054.html">S1a0</a></td>
-<td>񃰑</td>
-<td></td>
+<td class="signwriting">񃰑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00095.html">S158</a></td>
-<td>񂄑</td>
-<td></td>
+<td class="signwriting">񂄑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00222.html">S174</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00043.html">S118</a></td>
-<td>񀤑</td>
-<td></td>
+<td class="signwriting">񀤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00144.html">S1bb</a></td>
-<td>񄘱</td>
-<td></td>
+<td class="signwriting">񄘱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00134.html">S153</a></td>
-<td>񁼱</td>
-<td></td>
+<td class="signwriting">񁼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00039.html">S119</a></td>
-<td>񀥱</td>
-<td></td>
+<td class="signwriting">񀥱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00220.html">S16c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00101.html">S157</a></td>
-<td>񂂱</td>
-<td></td>
+<td class="signwriting">񂂱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00131.html">S17d</a></td>
-<td>񂻱</td>
-<td></td>
+<td class="signwriting">񂻱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00135.html">S154</a></td>
-<td>񁾑</td>
-<td></td>
+<td class="signwriting">񁾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00158.html">S1d4</a></td>
-<td>񄾑</td>
-<td></td>
+<td class="signwriting">񄾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00156.html">S1d2</a></td>
-<td>񄻑</td>
-<td></td>
+<td class="signwriting">񄻑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -460,8 +486,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00151.html">S18d</a></td>
-<td>񃓱</td>
-<td></td>
+<td class="signwriting">񃓱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -469,8 +495,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -478,8 +504,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00097.html">S145</a></td>
-<td>񁧱</td>
-<td></td>
+<td class="signwriting">񁧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -487,8 +513,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -496,8 +522,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00228.html">S17f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -505,8 +531,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -514,8 +540,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00111.html">S1ee</a></td>
-<td>񅥑</td>
-<td></td>
+<td class="signwriting">񅥑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -523,8 +549,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00140.html">S18b</a></td>
-<td>񃐱</td>
-<td></td>
+<td class="signwriting">񃐱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -532,8 +558,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00215.html">S166</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -541,8 +567,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00275.html">S1f1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -550,8 +576,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -559,8 +585,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00155.html">S1d1</a></td>
-<td>񄹱</td>
-<td></td>
+<td class="signwriting">񄹱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -568,8 +594,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00206.html">S15b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -577,8 +603,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00026.html">S1f2</a></td>
-<td>񅫁</td>
-<td></td>
+<td class="signwriting">񅫁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -586,8 +612,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00205.html">S156</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -595,8 +621,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00150.html">S18c</a></td>
-<td>񃒑</td>
-<td></td>
+<td class="signwriting">񃒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -604,8 +630,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00023.html">S1df</a></td>
-<td>񅎱</td>
-<td></td>
+<td class="signwriting">񅎱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -613,8 +639,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00166.html">S17e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -622,8 +648,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00165.html">S16f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -631,8 +657,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00087.html">S16e</a></td>
-<td>񂥑</td>
-<td></td>
+<td class="signwriting">񂥑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -640,8 +666,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00204.html">S152</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -649,8 +675,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00189.html">S133</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -658,8 +684,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00110.html">S1e4</a></td>
-<td>񅖑</td>
-<td></td>
+<td class="signwriting">񅖑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -667,8 +693,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00085.html">S149</a></td>
-<td>񁭱</td>
-<td></td>
+<td class="signwriting">񁭱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -676,8 +702,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00015.html">S108</a></td>
-<td>񀌑</td>
-<td></td>
+<td class="signwriting">񀌑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -685,8 +711,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00229.html">S181</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -694,8 +720,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00273.html">S1ec</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -703,8 +729,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00032.html">S1e2</a></td>
-<td>񅓁</td>
-<td></td>
+<td class="signwriting">񅓁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -712,8 +738,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00082.html">S14b</a></td>
-<td>񁰱</td>
-<td></td>
+<td class="signwriting">񁰱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -721,8 +747,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00116.html">S13f</a></td>
-<td>񁞱</td>
-<td></td>
+<td class="signwriting">񁞱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -730,8 +756,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00208.html">S15e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -739,8 +765,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00053.html">S19c</a></td>
-<td>񃪑</td>
-<td></td>
+<td class="signwriting">񃪑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -748,8 +774,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00040.html">S132</a></td>
-<td>񁋑</td>
-<td></td>
+<td class="signwriting">񁋑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -757,8 +783,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00059.html">S123</a></td>
-<td>񀴱</td>
-<td></td>
+<td class="signwriting">񀴱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -766,8 +792,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00224.html">S178</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -775,8 +801,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00271.html">S1e6</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -784,8 +810,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00153.html">S1c1</a></td>
-<td>񄡱</td>
-<td></td>
+<td class="signwriting">񄡱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -793,8 +819,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00031.html">S1e1</a></td>
-<td>񅑱</td>
-<td>񅑡</td>
+<td class="signwriting">񅑱</td>
+<td class="signwriting">񅑡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -802,8 +828,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00240.html">S19b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -811,8 +837,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00005.html">S1f9</a></td>
-<td>񅵱</td>
-<td></td>
+<td class="signwriting">񅵱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -820,8 +846,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00089.html">S171</a></td>
-<td>񂩱</td>
-<td></td>
+<td class="signwriting">񂩱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -829,8 +855,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00164.html">S14d</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -838,8 +864,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00141.html">S1a4</a></td>
-<td>񃶁</td>
-<td></td>
+<td class="signwriting">񃶁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -847,8 +873,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00267.html">S1cf</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -856,8 +882,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00061.html">S121</a></td>
-<td>񀱱</td>
-<td></td>
+<td class="signwriting">񀱱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -865,8 +891,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00183.html">S124</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -874,8 +900,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00030.html">S198</a></td>
-<td>񃤑</td>
-<td></td>
+<td class="signwriting">񃤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -883,8 +909,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00139.html">S187</a></td>
-<td>񃊱</td>
-<td></td>
+<td class="signwriting">񃊱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -892,8 +918,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00130.html">S17c</a></td>
-<td>񂺑</td>
-<td></td>
+<td class="signwriting">񂺑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -901,8 +927,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00025.html">S10c</a></td>
-<td>񀒑</td>
-<td></td>
+<td class="signwriting">񀒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -910,8 +936,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00038.html">S1b5</a></td>
-<td>񄏱</td>
-<td></td>
+<td class="signwriting">񄏱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -919,8 +945,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00058.html">S112</a></td>
-<td>񀛑</td>
-<td></td>
+<td class="signwriting">񀛑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -928,8 +954,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00246.html">S1a8</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -937,8 +963,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00180.html">S11c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -946,8 +972,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00157.html">S1d3</a></td>
-<td>񄼱</td>
-<td></td>
+<td class="signwriting">񄼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -955,8 +981,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00270.html">S1e3</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -964,8 +990,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00121.html">S128</a></td>
-<td>񀼑</td>
-<td></td>
+<td class="signwriting">񀼑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -973,8 +999,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -982,8 +1008,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00048.html">S11d</a></td>
-<td>񀫡</td>
-<td></td>
+<td class="signwriting">񀫡</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -991,8 +1017,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00124.html">S127</a></td>
-<td>񀺱</td>
-<td></td>
+<td class="signwriting">񀺱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1000,8 +1026,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00179.html">S11b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1009,8 +1035,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00190.html">S134</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1018,8 +1044,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00115.html">S13d</a></td>
-<td>񁛡</td>
-<td>񁛱</td>
+<td class="signwriting">񁛡</td>
+<td class="signwriting">񁛱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1027,8 +1053,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00003.html">S1f8</a></td>
-<td>񅴑</td>
-<td></td>
+<td class="signwriting">񅴑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1036,8 +1062,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00207.html">S15c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1045,8 +1071,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00237.html">S194</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1054,8 +1080,8 @@
 <td>4finNonspread</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00133.html">S160</a></td>
-<td>񂐑</td>
-<td></td>
+<td class="signwriting">񂐑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1063,8 +1089,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00216.html">S167</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1072,8 +1098,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00276.html">S1f6</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1081,8 +1107,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00014.html">S103</a></td>
-<td>񀄱</td>
-<td></td>
+<td class="signwriting">񀄱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1090,8 +1116,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00173.html">S10d</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1099,8 +1125,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00221.html">S172</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1108,8 +1134,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1117,8 +1143,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00277.html">S1fa</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1126,8 +1152,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00203.html">S151</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1135,8 +1161,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00154.html">S1c3</a></td>
-<td>񄤱</td>
-<td></td>
+<td class="signwriting">񄤱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1144,8 +1170,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00274.html">S1ef</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1153,8 +1179,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00006.html">S1fb</a></td>
-<td>񅸱</td>
-<td></td>
+<td class="signwriting">񅸱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1162,8 +1188,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00086.html">S168</a></td>
-<td>񂜑</td>
-<td></td>
+<td class="signwriting">񂜑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1171,8 +1197,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00261.html">S1c2</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1180,8 +1206,8 @@
 <td>3_spread</td>
 <td>extended</td>
 <td><a href="../segments/seg00074.html">S1c4</a></td>
-<td>񄦑</td>
-<td></td>
+<td class="signwriting">񄦑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1189,8 +1215,8 @@
 <td>4finSpread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00137.html">S155</a></td>
-<td>񁿱</td>
-<td></td>
+<td class="signwriting">񁿱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1198,8 +1224,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00146.html">S1d0</a></td>
-<td>񄸑</td>
-<td></td>
+<td class="signwriting">񄸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1207,8 +1233,8 @@
 <td>2finNonspread_othersFist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00118.html">S1a3</a></td>
-<td>񃴱</td>
-<td></td>
+<td class="signwriting">񃴱</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00031.html
+++ b/inventories/inv00031.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>LESCO (SP_101)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>LESCO (SP_101)</h1>
@@ -55,8 +81,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00032.html
+++ b/inventories/inv00032.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ČZJ (SP_52)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>ČZJ (SP_52)</h1>
@@ -55,8 +81,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00108.html">S1ed</a></td>
-<td>񅣡</td>
-<td>񅢑</td>
+<td class="signwriting">񅣡</td>
+<td class="signwriting">񅢑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00135.html">S154</a></td>
-<td>񁾑</td>
-<td></td>
+<td class="signwriting">񁾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00083.html">S180</a></td>
-<td>񃀑</td>
-<td>񃀁</td>
+<td class="signwriting">񃀑</td>
+<td class="signwriting">񃀁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00113.html">S1f4</a></td>
-<td>񅮁</td>
-<td>񅮑</td>
+<td class="signwriting">񅮁</td>
+<td class="signwriting">񅮑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00098.html">S14e</a></td>
-<td>񁵑</td>
-<td></td>
+<td class="signwriting">񁵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00103.html">S1c5</a></td>
-<td>񄧱</td>
-<td></td>
+<td class="signwriting">񄧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00220.html">S16c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00204.html">S152</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00043.html">S118</a></td>
-<td>񀤑</td>
-<td></td>
+<td class="signwriting">񀤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00111.html">S1ee</a></td>
-<td>񅥑</td>
-<td></td>
+<td class="signwriting">񅥑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00228.html">S17f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00134.html">S153</a></td>
-<td>񁼱</td>
-<td></td>
+<td class="signwriting">񁼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00088.html">S170</a></td>
-<td>񂨑</td>
-<td></td>
+<td class="signwriting">񂨑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>4finNonspread</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00133.html">S160</a></td>
-<td>񂐑</td>
-<td></td>
+<td class="signwriting">񂐑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00206.html">S15b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00158.html">S1d4</a></td>
-<td>񄾑</td>
-<td></td>
+<td class="signwriting">񄾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00229.html">S181</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00131.html">S17d</a></td>
-<td>񂻱</td>
-<td></td>
+<td class="signwriting">񂻱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00003.html">S1f8</a></td>
-<td>񅴑</td>
-<td></td>
+<td class="signwriting">񅴑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00162.html">S10b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00147.html">S1d5</a></td>
-<td>񄿱</td>
-<td></td>
+<td class="signwriting">񄿱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -460,8 +486,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00274.html">S1ef</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -469,8 +495,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00121.html">S128</a></td>
-<td>񀼑</td>
-<td></td>
+<td class="signwriting">񀼑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -478,8 +504,8 @@
 <td>4finSpread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00137.html">S155</a></td>
-<td>񁿱</td>
-<td></td>
+<td class="signwriting">񁿱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -487,8 +513,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00025.html">S10c</a></td>
-<td>񀒑</td>
-<td></td>
+<td class="signwriting">񀒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -496,8 +522,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00031.html">S1e1</a></td>
-<td>񅑱</td>
-<td>񅑡</td>
+<td class="signwriting">񅑱</td>
+<td class="signwriting">񅑡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -505,8 +531,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -514,8 +540,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -523,8 +549,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00116.html">S13f</a></td>
-<td>񁞱</td>
-<td></td>
+<td class="signwriting">񁞱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -532,8 +558,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00275.html">S1f1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -541,8 +567,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -550,8 +576,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00166.html">S17e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -559,8 +585,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00146.html">S1d0</a></td>
-<td>񄸑</td>
-<td></td>
+<td class="signwriting">񄸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -568,8 +594,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00101.html">S157</a></td>
-<td>񂂱</td>
-<td></td>
+<td class="signwriting">񂂱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -577,8 +603,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00165.html">S16f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -586,8 +612,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00087.html">S16e</a></td>
-<td>񂥑</td>
-<td></td>
+<td class="signwriting">񂥑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -595,8 +621,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00095.html">S158</a></td>
-<td>񂄑</td>
-<td></td>
+<td class="signwriting">񂄑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -604,8 +630,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00110.html">S1e4</a></td>
-<td>񅖑</td>
-<td></td>
+<td class="signwriting">񅖑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -613,8 +639,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -622,8 +648,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00205.html">S156</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -631,8 +657,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00089.html">S171</a></td>
-<td>񂩱</td>
-<td></td>
+<td class="signwriting">񂩱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -640,8 +666,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00039.html">S119</a></td>
-<td>񀥱</td>
-<td></td>
+<td class="signwriting">񀥱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -649,8 +675,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00130.html">S17c</a></td>
-<td>񂺑</td>
-<td></td>
+<td class="signwriting">񂺑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -658,8 +684,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00225.html">S179</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -667,8 +693,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00144.html">S1bb</a></td>
-<td>񄘱</td>
-<td></td>
+<td class="signwriting">񄘱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -676,8 +702,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00208.html">S15e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -685,8 +711,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00227.html">S17b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -694,8 +720,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00155.html">S1d1</a></td>
-<td>񄹱</td>
-<td></td>
+<td class="signwriting">񄹱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -703,8 +729,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00124.html">S127</a></td>
-<td>񀺱</td>
-<td></td>
+<td class="signwriting">񀺱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -712,8 +738,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00202.html">S14f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -721,8 +747,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00216.html">S167</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -730,8 +756,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00273.html">S1ec</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -739,8 +765,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00123.html">S12b</a></td>
-<td>񁀱</td>
-<td></td>
+<td class="signwriting">񁀱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -748,8 +774,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00221.html">S172</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -757,8 +783,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00222.html">S174</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -766,8 +792,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00224.html">S178</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -775,8 +801,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00115.html">S13d</a></td>
-<td>񁛡</td>
-<td>񁛱</td>
+<td class="signwriting">񁛡</td>
+<td class="signwriting">񁛱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -784,8 +810,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00267.html">S1cf</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -793,8 +819,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00022.html">S1de</a></td>
-<td>񅍑</td>
-<td></td>
+<td class="signwriting">񅍑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -802,8 +828,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00030.html">S198</a></td>
-<td>񃤑</td>
-<td></td>
+<td class="signwriting">񃤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -811,8 +837,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00097.html">S145</a></td>
-<td>񁧱</td>
-<td></td>
+<td class="signwriting">񁧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -820,8 +846,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -829,8 +855,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00163.html">S14a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -838,8 +864,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00062.html">S122</a></td>
-<td>񀳑</td>
-<td></td>
+<td class="signwriting">񀳑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -847,8 +873,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00023.html">S1df</a></td>
-<td>񅎱</td>
-<td></td>
+<td class="signwriting">񅎱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -856,8 +882,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -865,8 +891,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00006.html">S1fb</a></td>
-<td>񅸱</td>
-<td></td>
+<td class="signwriting">񅸱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -874,8 +900,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00153.html">S1c1</a></td>
-<td>񄡱</td>
-<td></td>
+<td class="signwriting">񄡱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -883,8 +909,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00127.html">S173</a></td>
-<td>񂬱</td>
-<td></td>
+<td class="signwriting">񂬱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -892,8 +918,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00223.html">S175</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -901,8 +927,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00032.html">S1e2</a></td>
-<td>񅓁</td>
-<td></td>
+<td class="signwriting">񅓁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -910,8 +936,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00005.html">S1f9</a></td>
-<td>񅵱</td>
-<td></td>
+<td class="signwriting">񅵱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -919,8 +945,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00102.html">S1a7</a></td>
-<td>񃺱</td>
-<td></td>
+<td class="signwriting">񃺱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -928,8 +954,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00154.html">S1c3</a></td>
-<td>񄤱</td>
-<td></td>
+<td class="signwriting">񄤱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -937,8 +963,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00082.html">S14b</a></td>
-<td>񁰱</td>
-<td></td>
+<td class="signwriting">񁰱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -946,8 +972,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00150.html">S18c</a></td>
-<td>񃒑</td>
-<td></td>
+<td class="signwriting">񃒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -955,8 +981,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00272.html">S1e8</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -964,8 +990,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00054.html">S1a0</a></td>
-<td>񃰑</td>
-<td></td>
+<td class="signwriting">񃰑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -973,8 +999,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00277.html">S1fa</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -982,8 +1008,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00226.html">S17a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -991,8 +1017,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00164.html">S14d</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1000,8 +1026,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00190.html">S134</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1009,8 +1035,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00241.html">S19d</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1018,8 +1044,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00270.html">S1e3</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1027,8 +1053,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00271.html">S1e6</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1036,8 +1062,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00191.html">S135</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1045,8 +1071,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00114.html">S129</a></td>
-<td>񀽱</td>
-<td></td>
+<td class="signwriting">񀽱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1054,8 +1080,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00105.html">S1e5</a></td>
-<td>񅗱</td>
-<td></td>
+<td class="signwriting">񅗱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1063,8 +1089,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00096.html">S159</a></td>
-<td>񂅱</td>
-<td></td>
+<td class="signwriting">񂅱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1072,8 +1098,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00053.html">S19c</a></td>
-<td>񃪑</td>
-<td></td>
+<td class="signwriting">񃪑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1081,8 +1107,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1090,8 +1116,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00151.html">S18d</a></td>
-<td>񃓱</td>
-<td></td>
+<td class="signwriting">񃓱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1099,8 +1125,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00174.html">S10f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1108,8 +1134,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00024.html">S1e0</a></td>
-<td>񅐁</td>
-<td>񅐑</td>
+<td class="signwriting">񅐁</td>
+<td class="signwriting">񅐑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1117,8 +1143,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00207.html">S15c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1126,8 +1152,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00215.html">S166</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1135,8 +1161,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00156.html">S1d2</a></td>
-<td>񄻑</td>
-<td></td>
+<td class="signwriting">񄻑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1144,8 +1170,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00058.html">S112</a></td>
-<td>񀛑</td>
-<td></td>
+<td class="signwriting">񀛑</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00033.html
+++ b/inventories/inv00033.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>DGS (SP_53)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>DGS (SP_53)</h1>
@@ -55,8 +81,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00083.html">S180</a></td>
-<td>񃀑</td>
-<td>񃀁</td>
+<td class="signwriting">񃀑</td>
+<td class="signwriting">񃀁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00108.html">S1ed</a></td>
-<td>񅣡</td>
-<td>񅢑</td>
+<td class="signwriting">񅣡</td>
+<td class="signwriting">񅢑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00113.html">S1f4</a></td>
-<td>񅮁</td>
-<td>񅮑</td>
+<td class="signwriting">񅮁</td>
+<td class="signwriting">񅮑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00134.html">S153</a></td>
-<td>񁼱</td>
-<td></td>
+<td class="signwriting">񁼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00098.html">S14e</a></td>
-<td>񁵑</td>
-<td></td>
+<td class="signwriting">񁵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>4finNonspread</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00133.html">S160</a></td>
-<td>񂐑</td>
-<td></td>
+<td class="signwriting">񂐑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00043.html">S118</a></td>
-<td>񀤑</td>
-<td></td>
+<td class="signwriting">񀤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00131.html">S17d</a></td>
-<td>񂻱</td>
-<td></td>
+<td class="signwriting">񂻱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00025.html">S10c</a></td>
-<td>񀒑</td>
-<td></td>
+<td class="signwriting">񀒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00162.html">S10b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00274.html">S1ef</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00135.html">S154</a></td>
-<td>񁾑</td>
-<td></td>
+<td class="signwriting">񁾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00275.html">S1f1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00158.html">S1d4</a></td>
-<td>񄾑</td>
-<td></td>
+<td class="signwriting">񄾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00095.html">S158</a></td>
-<td>񂄑</td>
-<td></td>
+<td class="signwriting">񂄑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00165.html">S16f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00039.html">S119</a></td>
-<td>񀥱</td>
-<td></td>
+<td class="signwriting">񀥱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00204.html">S152</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00031.html">S1e1</a></td>
-<td>񅑱</td>
-<td>񅑡</td>
+<td class="signwriting">񅑱</td>
+<td class="signwriting">񅑡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00229.html">S181</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -460,8 +486,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -469,8 +495,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -478,8 +504,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -487,8 +513,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00163.html">S14a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -496,8 +522,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00022.html">S1de</a></td>
-<td>񅍑</td>
-<td></td>
+<td class="signwriting">񅍑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -505,8 +531,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00273.html">S1ec</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -514,8 +540,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00228.html">S17f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -523,8 +549,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00151.html">S18d</a></td>
-<td>񃓱</td>
-<td></td>
+<td class="signwriting">񃓱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -532,8 +558,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00103.html">S1c5</a></td>
-<td>񄧱</td>
-<td></td>
+<td class="signwriting">񄧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -541,8 +567,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -550,8 +576,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00089.html">S171</a></td>
-<td>񂩱</td>
-<td></td>
+<td class="signwriting">񂩱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -559,8 +585,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00054.html">S1a0</a></td>
-<td>񃰑</td>
-<td></td>
+<td class="signwriting">񃰑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -568,8 +594,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -577,8 +603,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00026.html">S1f2</a></td>
-<td>񅫁</td>
-<td></td>
+<td class="signwriting">񅫁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -586,8 +612,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00139.html">S187</a></td>
-<td>񃊱</td>
-<td></td>
+<td class="signwriting">񃊱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -595,8 +621,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00223.html">S175</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -604,8 +630,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00277.html">S1fa</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -613,8 +639,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00166.html">S17e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -622,8 +648,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00110.html">S1e4</a></td>
-<td>񅖑</td>
-<td></td>
+<td class="signwriting">񅖑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -631,8 +657,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00101.html">S157</a></td>
-<td>񂂱</td>
-<td></td>
+<td class="signwriting">񂂱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -640,8 +666,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00111.html">S1ee</a></td>
-<td>񅥑</td>
-<td></td>
+<td class="signwriting">񅥑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -649,8 +675,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00116.html">S13f</a></td>
-<td>񁞱</td>
-<td></td>
+<td class="signwriting">񁞱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -658,8 +684,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00005.html">S1f9</a></td>
-<td>񅵱</td>
-<td></td>
+<td class="signwriting">񅵱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -667,8 +693,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00155.html">S1d1</a></td>
-<td>񄹱</td>
-<td></td>
+<td class="signwriting">񄹱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -676,8 +702,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00032.html">S1e2</a></td>
-<td>񅓁</td>
-<td></td>
+<td class="signwriting">񅓁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -685,8 +711,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00153.html">S1c1</a></td>
-<td>񄡱</td>
-<td></td>
+<td class="signwriting">񄡱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -694,8 +720,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00121.html">S128</a></td>
-<td>񀼑</td>
-<td></td>
+<td class="signwriting">񀼑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -703,8 +729,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00006.html">S1fb</a></td>
-<td>񅸱</td>
-<td></td>
+<td class="signwriting">񅸱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -712,8 +738,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00256.html">S1bc</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -721,8 +747,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00152.html">S1da</a></td>
-<td>񅇑</td>
-<td></td>
+<td class="signwriting">񅇑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -730,8 +756,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00205.html">S156</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -739,8 +765,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00058.html">S112</a></td>
-<td>񀛑</td>
-<td></td>
+<td class="signwriting">񀛑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -748,8 +774,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00217.html">S169</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -757,8 +783,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00106.html">S1e7</a></td>
-<td>񅚱</td>
-<td></td>
+<td class="signwriting">񅚱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -766,8 +792,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00114.html">S129</a></td>
-<td>񀽱</td>
-<td></td>
+<td class="signwriting">񀽱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -775,8 +801,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00220.html">S16c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -784,8 +810,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00167.html">S1cd</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -793,8 +819,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00234.html">S189</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -802,8 +828,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00082.html">S14b</a></td>
-<td>񁰱</td>
-<td></td>
+<td class="signwriting">񁰱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -811,8 +837,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00061.html">S121</a></td>
-<td>񀱱</td>
-<td></td>
+<td class="signwriting">񀱱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -820,8 +846,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00154.html">S1c3</a></td>
-<td>񄤱</td>
-<td></td>
+<td class="signwriting">񄤱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -829,8 +855,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00246.html">S1a8</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -838,8 +864,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00144.html">S1bb</a></td>
-<td>񄘱</td>
-<td></td>
+<td class="signwriting">񄘱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -847,8 +873,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00142.html">S1a5</a></td>
-<td>񃷱</td>
-<td></td>
+<td class="signwriting">񃷱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -856,8 +882,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00267.html">S1cf</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -865,8 +891,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00023.html">S1df</a></td>
-<td>񅎱</td>
-<td></td>
+<td class="signwriting">񅎱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -874,8 +900,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00053.html">S19c</a></td>
-<td>񃪑</td>
-<td></td>
+<td class="signwriting">񃪑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -883,8 +909,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00146.html">S1d0</a></td>
-<td>񄸑</td>
-<td></td>
+<td class="signwriting">񄸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -892,8 +918,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00003.html">S1f8</a></td>
-<td>񅴑</td>
-<td></td>
+<td class="signwriting">񅴑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -901,8 +927,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00130.html">S17c</a></td>
-<td>񂺑</td>
-<td></td>
+<td class="signwriting">񂺑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -910,8 +936,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -919,8 +945,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00232.html">S186</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00034.html
+++ b/inventories/inv00034.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>DSL, DTS (SP_30)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>DSL, DTS (SP_30)</h1>
@@ -55,8 +81,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00108.html">S1ed</a></td>
-<td>񅣡</td>
-<td>񅢑</td>
+<td class="signwriting">񅣡</td>
+<td class="signwriting">񅢑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00134.html">S153</a></td>
-<td>񁼱</td>
-<td></td>
+<td class="signwriting">񁼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00139.html">S187</a></td>
-<td>񃊱</td>
-<td></td>
+<td class="signwriting">񃊱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00058.html">S112</a></td>
-<td>񀛑</td>
-<td></td>
+<td class="signwriting">񀛑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00039.html">S119</a></td>
-<td>񀥱</td>
-<td></td>
+<td class="signwriting">񀥱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00151.html">S18d</a></td>
-<td>񃓱</td>
-<td></td>
+<td class="signwriting">񃓱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00026.html">S1f2</a></td>
-<td>񅫁</td>
-<td></td>
+<td class="signwriting">񅫁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00159.html">S1d8</a></td>
-<td>񅄑</td>
-<td></td>
+<td class="signwriting">񅄑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00163.html">S14a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00144.html">S1bb</a></td>
-<td>񄘱</td>
-<td></td>
+<td class="signwriting">񄘱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00142.html">S1a5</a></td>
-<td>񃷱</td>
-<td></td>
+<td class="signwriting">񃷱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00035.html
+++ b/inventories/inv00035.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>LSEC (SP_136)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>LSEC (SP_136)</h1>
@@ -55,8 +81,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00036.html
+++ b/inventories/inv00036.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>EVK (SP_109)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>EVK (SP_109)</h1>
@@ -55,8 +81,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00037.html
+++ b/inventories/inv00037.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ESL (SP_84)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>ESL (SP_84)</h1>
@@ -55,8 +81,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00038.html
+++ b/inventories/inv00038.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>LSE (SP_55)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>LSE (SP_55)</h1>
@@ -55,8 +81,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00134.html">S153</a></td>
-<td>񁼱</td>
-<td></td>
+<td class="signwriting">񁼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00101.html">S157</a></td>
-<td>񂂱</td>
-<td></td>
+<td class="signwriting">񂂱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00054.html">S1a0</a></td>
-<td>񃰑</td>
-<td></td>
+<td class="signwriting">񃰑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00113.html">S1f4</a></td>
-<td>񅮁</td>
-<td>񅮑</td>
+<td class="signwriting">񅮁</td>
+<td class="signwriting">񅮑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00220.html">S16c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00098.html">S14e</a></td>
-<td>񁵑</td>
-<td></td>
+<td class="signwriting">񁵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00083.html">S180</a></td>
-<td>񃀑</td>
-<td>񃀁</td>
+<td class="signwriting">񃀑</td>
+<td class="signwriting">񃀁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00158.html">S1d4</a></td>
-<td>񄾑</td>
-<td></td>
+<td class="signwriting">񄾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00108.html">S1ed</a></td>
-<td>񅣡</td>
-<td>񅢑</td>
+<td class="signwriting">񅣡</td>
+<td class="signwriting">񅢑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00131.html">S17d</a></td>
-<td>񂻱</td>
-<td></td>
+<td class="signwriting">񂻱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00144.html">S1bb</a></td>
-<td>񄘱</td>
-<td></td>
+<td class="signwriting">񄘱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00274.html">S1ef</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00043.html">S118</a></td>
-<td>񀤑</td>
-<td></td>
+<td class="signwriting">񀤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00103.html">S1c5</a></td>
-<td>񄧱</td>
-<td></td>
+<td class="signwriting">񄧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00241.html">S19d</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00089.html">S171</a></td>
-<td>񂩱</td>
-<td></td>
+<td class="signwriting">񂩱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00156.html">S1d2</a></td>
-<td>񄻑</td>
-<td></td>
+<td class="signwriting">񄻑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00267.html">S1cf</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00232.html">S186</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00155.html">S1d1</a></td>
-<td>񄹱</td>
-<td></td>
+<td class="signwriting">񄹱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -460,8 +486,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -469,8 +495,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -478,8 +504,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00114.html">S129</a></td>
-<td>񀽱</td>
-<td></td>
+<td class="signwriting">񀽱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -487,8 +513,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00157.html">S1d3</a></td>
-<td>񄼱</td>
-<td></td>
+<td class="signwriting">񄼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -496,8 +522,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00273.html">S1ec</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -505,8 +531,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00275.html">S1f1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -514,8 +540,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00165.html">S16f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -523,8 +549,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00116.html">S13f</a></td>
-<td>񁞱</td>
-<td></td>
+<td class="signwriting">񁞱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -532,8 +558,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -541,8 +567,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00276.html">S1f6</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -550,8 +576,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00115.html">S13d</a></td>
-<td>񁛡</td>
-<td>񁛱</td>
+<td class="signwriting">񁛡</td>
+<td class="signwriting">񁛱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -559,8 +585,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -568,8 +594,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00153.html">S1c1</a></td>
-<td>񄡱</td>
-<td></td>
+<td class="signwriting">񄡱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -577,8 +603,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00110.html">S1e4</a></td>
-<td>񅖑</td>
-<td></td>
+<td class="signwriting">񅖑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -586,8 +612,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00216.html">S167</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -595,8 +621,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -604,8 +630,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00190.html">S134</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -613,8 +639,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00031.html">S1e1</a></td>
-<td>񅑱</td>
-<td>񅑡</td>
+<td class="signwriting">񅑱</td>
+<td class="signwriting">񅑡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -622,8 +648,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00261.html">S1c2</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -631,8 +657,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00277.html">S1fa</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -640,8 +666,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -649,8 +675,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00245.html">S1a6</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -658,8 +684,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00150.html">S18c</a></td>
-<td>񃒑</td>
-<td></td>
+<td class="signwriting">񃒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -667,8 +693,8 @@
 <td>4finNonspread</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00133.html">S160</a></td>
-<td>񂐑</td>
-<td></td>
+<td class="signwriting">񂐑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -676,8 +702,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00003.html">S1f8</a></td>
-<td>񅴑</td>
-<td></td>
+<td class="signwriting">񅴑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -685,8 +711,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00097.html">S145</a></td>
-<td>񁧱</td>
-<td></td>
+<td class="signwriting">񁧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -694,8 +720,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00124.html">S127</a></td>
-<td>񀺱</td>
-<td></td>
+<td class="signwriting">񀺱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -703,8 +729,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00246.html">S1a8</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -712,8 +738,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00121.html">S128</a></td>
-<td>񀼑</td>
-<td></td>
+<td class="signwriting">񀼑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -721,8 +747,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00135.html">S154</a></td>
-<td>񁾑</td>
-<td></td>
+<td class="signwriting">񁾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -730,8 +756,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00227.html">S17b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -739,8 +765,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00229.html">S181</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -748,8 +774,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00228.html">S17f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -757,8 +783,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00053.html">S19c</a></td>
-<td>񃪑</td>
-<td></td>
+<td class="signwriting">񃪑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -766,8 +792,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00127.html">S173</a></td>
-<td>񂬱</td>
-<td></td>
+<td class="signwriting">񂬱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -775,8 +801,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00039.html">S119</a></td>
-<td>񀥱</td>
-<td></td>
+<td class="signwriting">񀥱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -784,8 +810,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00048.html">S11d</a></td>
-<td>񀫡</td>
-<td></td>
+<td class="signwriting">񀫡</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -793,8 +819,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00102.html">S1a7</a></td>
-<td>񃺱</td>
-<td></td>
+<td class="signwriting">񃺱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -802,8 +828,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00177.html">S114</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -811,8 +837,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00154.html">S1c3</a></td>
-<td>񄤱</td>
-<td></td>
+<td class="signwriting">񄤱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -820,8 +846,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00022.html">S1de</a></td>
-<td>񅍑</td>
-<td></td>
+<td class="signwriting">񅍑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -829,8 +855,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00233.html">S188</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -838,8 +864,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00194.html">S138</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -847,8 +873,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00032.html">S1e2</a></td>
-<td>񅓁</td>
-<td></td>
+<td class="signwriting">񅓁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -856,8 +882,8 @@
 <td>3_spread</td>
 <td>extended</td>
 <td><a href="../segments/seg00074.html">S1c4</a></td>
-<td>񄦑</td>
-<td></td>
+<td class="signwriting">񄦑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -865,8 +891,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00217.html">S169</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -874,8 +900,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00223.html">S175</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -883,8 +909,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00065.html">S142</a></td>
-<td>񁣑</td>
-<td></td>
+<td class="signwriting">񁣑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -892,8 +918,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00030.html">S198</a></td>
-<td>񃤑</td>
-<td></td>
+<td class="signwriting">񃤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -901,8 +927,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00221.html">S172</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -910,8 +936,8 @@
 <td>3_nonspread</td>
 <td>extended</td>
 <td><a href="../segments/seg00066.html">S18e</a></td>
-<td>񃕑</td>
-<td></td>
+<td class="signwriting">񃕑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -919,8 +945,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00180.html">S11c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -928,8 +954,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00203.html">S151</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -937,8 +963,8 @@
 <td>2finNonspread_othersFist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00118.html">S1a3</a></td>
-<td>񃴱</td>
-<td></td>
+<td class="signwriting">񃴱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -946,8 +972,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00027.html">S1f3</a></td>
-<td>񅬱</td>
-<td></td>
+<td class="signwriting">񅬱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -955,8 +981,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00166.html">S17e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -964,8 +990,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00005.html">S1f9</a></td>
-<td>񅵱</td>
-<td></td>
+<td class="signwriting">񅵱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -973,8 +999,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00254.html">S1b8</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -982,8 +1008,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00057.html">S1cb</a></td>
-<td>񄰱</td>
-<td></td>
+<td class="signwriting">񄰱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -991,8 +1017,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00191.html">S135</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1000,8 +1026,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00130.html">S17c</a></td>
-<td>񂺑</td>
-<td></td>
+<td class="signwriting">񂺑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1009,8 +1035,8 @@
 <td>3_spread</td>
 <td>extended</td>
 <td><a href="../segments/seg00071.html">S18f</a></td>
-<td>񃖱</td>
-<td></td>
+<td class="signwriting">񃖱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1018,8 +1044,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00146.html">S1d0</a></td>
-<td>񄸑</td>
-<td></td>
+<td class="signwriting">񄸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1027,8 +1053,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00202.html">S14f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1036,8 +1062,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00230.html">S183</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1045,8 +1071,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00213.html">S164</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1054,8 +1080,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00163.html">S14a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1063,8 +1089,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00167.html">S1cd</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1072,8 +1098,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00006.html">S1fb</a></td>
-<td>񅸱</td>
-<td></td>
+<td class="signwriting">񅸱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1081,8 +1107,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00226.html">S17a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1090,8 +1116,8 @@
 <td>1fin_othersNonfist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00160.html">S105</a></td>
-<td>񀇱</td>
-<td></td>
+<td class="signwriting">񀇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1099,8 +1125,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00204.html">S152</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1108,8 +1134,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00143.html">S1ba</a></td>
-<td>񄗁</td>
-<td></td>
+<td class="signwriting">񄗁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1117,8 +1143,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00141.html">S1a4</a></td>
-<td>񃶁</td>
-<td></td>
+<td class="signwriting">񃶁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1126,8 +1152,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00171.html">S107</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1135,8 +1161,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00253.html">S1b7</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1144,8 +1170,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00264.html">S1c9</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1153,8 +1179,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00185.html">S12e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1162,8 +1188,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00271.html">S1e6</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1171,8 +1197,8 @@
 <td>2finNonspread_othersFist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00120.html">S1b3</a></td>
-<td>񄌱</td>
-<td></td>
+<td class="signwriting">񄌱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1180,8 +1206,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00088.html">S170</a></td>
-<td>񂨑</td>
-<td></td>
+<td class="signwriting">񂨑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1189,8 +1215,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00046.html">S116</a></td>
-<td>񀡑</td>
-<td></td>
+<td class="signwriting">񀡑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1198,8 +1224,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00024.html">S1e0</a></td>
-<td>񅐁</td>
-<td>񅐑</td>
+<td class="signwriting">񅐁</td>
+<td class="signwriting">񅐑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1207,8 +1233,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00152.html">S1da</a></td>
-<td>񅇑</td>
-<td></td>
+<td class="signwriting">񅇑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1216,8 +1242,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00272.html">S1e8</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1225,8 +1251,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00206.html">S15b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1234,8 +1260,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00259.html">S1bf</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1243,8 +1269,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00140.html">S18b</a></td>
-<td>񃐱</td>
-<td></td>
+<td class="signwriting">񃐱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1252,8 +1278,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00105.html">S1e5</a></td>
-<td>񅗱</td>
-<td></td>
+<td class="signwriting">񅗱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1261,8 +1287,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00234.html">S189</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1270,8 +1296,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00019.html">S1ae</a></td>
-<td>񄅑</td>
-<td></td>
+<td class="signwriting">񄅑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1279,8 +1305,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00123.html">S12b</a></td>
-<td>񁀱</td>
-<td></td>
+<td class="signwriting">񁀱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1288,8 +1314,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00212.html">S163</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1297,8 +1323,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00209.html">S15f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1306,8 +1332,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00162.html">S10b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00039.html
+++ b/inventories/inv00039.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>LSC (CT) (SP_56)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>LSC (CT) (SP_56)</h1>
@@ -55,8 +81,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00113.html">S1f4</a></td>
-<td>񅮁</td>
-<td>񅮑</td>
+<td class="signwriting">񅮁</td>
+<td class="signwriting">񅮑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00108.html">S1ed</a></td>
-<td>񅣡</td>
-<td>񅢑</td>
+<td class="signwriting">񅣡</td>
+<td class="signwriting">񅢑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00158.html">S1d4</a></td>
-<td>񄾑</td>
-<td></td>
+<td class="signwriting">񄾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00083.html">S180</a></td>
-<td>񃀑</td>
-<td>񃀁</td>
+<td class="signwriting">񃀑</td>
+<td class="signwriting">񃀁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00054.html">S1a0</a></td>
-<td>񃰑</td>
-<td></td>
+<td class="signwriting">񃰑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00098.html">S14e</a></td>
-<td>񁵑</td>
-<td></td>
+<td class="signwriting">񁵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00162.html">S10b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00135.html">S154</a></td>
-<td>񁾑</td>
-<td></td>
+<td class="signwriting">񁾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00101.html">S157</a></td>
-<td>񂂱</td>
-<td></td>
+<td class="signwriting">񂂱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00131.html">S17d</a></td>
-<td>񂻱</td>
-<td></td>
+<td class="signwriting">񂻱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00005.html">S1f9</a></td>
-<td>񅵱</td>
-<td></td>
+<td class="signwriting">񅵱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00173.html">S10d</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00134.html">S153</a></td>
-<td>񁼱</td>
-<td></td>
+<td class="signwriting">񁼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00043.html">S118</a></td>
-<td>񀤑</td>
-<td></td>
+<td class="signwriting">񀤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00144.html">S1bb</a></td>
-<td>񄘱</td>
-<td></td>
+<td class="signwriting">񄘱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00103.html">S1c5</a></td>
-<td>񄧱</td>
-<td></td>
+<td class="signwriting">񄧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00274.html">S1ef</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00273.html">S1ec</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00153.html">S1c1</a></td>
-<td>񄡱</td>
-<td></td>
+<td class="signwriting">񄡱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00165.html">S16f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -460,8 +486,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -469,8 +495,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00216.html">S167</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -478,8 +504,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00267.html">S1cf</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -487,8 +513,8 @@
 <td>4finSpread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00137.html">S155</a></td>
-<td>񁿱</td>
-<td></td>
+<td class="signwriting">񁿱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -496,8 +522,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00232.html">S186</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -505,8 +531,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00111.html">S1ee</a></td>
-<td>񅥑</td>
-<td></td>
+<td class="signwriting">񅥑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -514,8 +540,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00121.html">S128</a></td>
-<td>񀼑</td>
-<td></td>
+<td class="signwriting">񀼑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -523,8 +549,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -532,8 +558,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -541,8 +567,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00095.html">S158</a></td>
-<td>񂄑</td>
-<td></td>
+<td class="signwriting">񂄑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -550,8 +576,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00110.html">S1e4</a></td>
-<td>񅖑</td>
-<td></td>
+<td class="signwriting">񅖑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -559,8 +585,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00156.html">S1d2</a></td>
-<td>񄻑</td>
-<td></td>
+<td class="signwriting">񄻑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -568,8 +594,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00130.html">S17c</a></td>
-<td>񂺑</td>
-<td></td>
+<td class="signwriting">񂺑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -577,8 +603,8 @@
 <td>1fin_othersNonfist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00160.html">S105</a></td>
-<td>񀇱</td>
-<td></td>
+<td class="signwriting">񀇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -586,8 +612,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00115.html">S13d</a></td>
-<td>񁛡</td>
-<td>񁛱</td>
+<td class="signwriting">񁛡</td>
+<td class="signwriting">񁛱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -595,8 +621,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00089.html">S171</a></td>
-<td>񂩱</td>
-<td></td>
+<td class="signwriting">񂩱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -604,8 +630,8 @@
 <td>4finNonspread</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00133.html">S160</a></td>
-<td>񂐑</td>
-<td></td>
+<td class="signwriting">񂐑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -613,8 +639,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00058.html">S112</a></td>
-<td>񀛑</td>
-<td></td>
+<td class="signwriting">񀛑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -622,8 +648,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -631,8 +657,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00087.html">S16e</a></td>
-<td>񂥑</td>
-<td></td>
+<td class="signwriting">񂥑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -640,8 +666,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00220.html">S16c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -649,8 +675,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00224.html">S178</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -658,8 +684,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00155.html">S1d1</a></td>
-<td>񄹱</td>
-<td></td>
+<td class="signwriting">񄹱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -667,8 +693,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00166.html">S17e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -676,8 +702,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00150.html">S18c</a></td>
-<td>񃒑</td>
-<td></td>
+<td class="signwriting">񃒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -685,8 +711,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00114.html">S129</a></td>
-<td>񀽱</td>
-<td></td>
+<td class="signwriting">񀽱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -694,8 +720,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00221.html">S172</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -703,8 +729,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00277.html">S1fa</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -712,8 +738,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00116.html">S13f</a></td>
-<td>񁞱</td>
-<td></td>
+<td class="signwriting">񁞱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -721,8 +747,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00275.html">S1f1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -730,8 +756,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00190.html">S134</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -739,8 +765,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00082.html">S14b</a></td>
-<td>񁰱</td>
-<td></td>
+<td class="signwriting">񁰱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -748,8 +774,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00241.html">S19d</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -757,8 +783,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -766,8 +792,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00039.html">S119</a></td>
-<td>񀥱</td>
-<td></td>
+<td class="signwriting">񀥱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -775,8 +801,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00124.html">S127</a></td>
-<td>񀺱</td>
-<td></td>
+<td class="signwriting">񀺱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -784,8 +810,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00264.html">S1c9</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -793,8 +819,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00228.html">S17f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -802,8 +828,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00157.html">S1d3</a></td>
-<td>񄼱</td>
-<td></td>
+<td class="signwriting">񄼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -811,8 +837,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -820,8 +846,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00180.html">S11c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -829,8 +855,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00040.html">S132</a></td>
-<td>񁋑</td>
-<td></td>
+<td class="signwriting">񁋑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -838,8 +864,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00229.html">S181</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -847,8 +873,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00106.html">S1e7</a></td>
-<td>񅚱</td>
-<td></td>
+<td class="signwriting">񅚱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -856,8 +882,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00245.html">S1a6</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -865,8 +891,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00254.html">S1b8</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -874,8 +900,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00204.html">S152</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -883,8 +909,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00031.html">S1e1</a></td>
-<td>񅑱</td>
-<td>񅑡</td>
+<td class="signwriting">񅑱</td>
+<td class="signwriting">񅑡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -892,8 +918,8 @@
 <td>2finNonspread_othersFist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00120.html">S1b3</a></td>
-<td>񄌱</td>
-<td></td>
+<td class="signwriting">񄌱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -901,8 +927,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00181.html">S11f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -910,8 +936,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00225.html">S179</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -919,8 +945,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00227.html">S17b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -928,8 +954,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00048.html">S11d</a></td>
-<td>񀫡</td>
-<td></td>
+<td class="signwriting">񀫡</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -937,8 +963,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00061.html">S121</a></td>
-<td>񀱱</td>
-<td></td>
+<td class="signwriting">񀱱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -946,8 +972,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00026.html">S1f2</a></td>
-<td>񅫁</td>
-<td></td>
+<td class="signwriting">񅫁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -955,8 +981,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00025.html">S10c</a></td>
-<td>񀒑</td>
-<td></td>
+<td class="signwriting">񀒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -964,8 +990,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00006.html">S1fb</a></td>
-<td>񅸱</td>
-<td></td>
+<td class="signwriting">񅸱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -973,8 +999,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00276.html">S1f6</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -982,8 +1008,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00140.html">S18b</a></td>
-<td>񃐱</td>
-<td></td>
+<td class="signwriting">񃐱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -991,8 +1017,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00038.html">S1b5</a></td>
-<td>񄏱</td>
-<td></td>
+<td class="signwriting">񄏱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1000,8 +1026,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00094.html">S146</a></td>
-<td>񁩑</td>
-<td></td>
+<td class="signwriting">񁩑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1009,8 +1035,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00020.html">S1c6</a></td>
-<td>񄩁</td>
-<td>񄩑</td>
+<td class="signwriting">񄩁</td>
+<td class="signwriting">񄩑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1018,8 +1044,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00022.html">S1de</a></td>
-<td>񅍑</td>
-<td></td>
+<td class="signwriting">񅍑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1027,8 +1053,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00088.html">S170</a></td>
-<td>񂨑</td>
-<td></td>
+<td class="signwriting">񂨑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1036,8 +1062,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00019.html">S1ae</a></td>
-<td>񄅑</td>
-<td></td>
+<td class="signwriting">񄅑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1045,8 +1071,8 @@
 <td>3_spread</td>
 <td>extended</td>
 <td><a href="../segments/seg00074.html">S1c4</a></td>
-<td>񄦑</td>
-<td></td>
+<td class="signwriting">񄦑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1054,8 +1080,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00272.html">S1e8</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1063,8 +1089,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00146.html">S1d0</a></td>
-<td>񄸑</td>
-<td></td>
+<td class="signwriting">񄸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1072,8 +1098,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00171.html">S107</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1081,8 +1107,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00127.html">S173</a></td>
-<td>񂬱</td>
-<td></td>
+<td class="signwriting">񂬱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1090,8 +1116,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00163.html">S14a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1099,8 +1125,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00261.html">S1c2</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1108,8 +1134,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00046.html">S116</a></td>
-<td>񀡑</td>
-<td></td>
+<td class="signwriting">񀡑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1117,8 +1143,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00172.html">S109</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1126,8 +1152,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00167.html">S1cd</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1135,8 +1161,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00260.html">S1c0</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1144,8 +1170,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00151.html">S18d</a></td>
-<td>񃓱</td>
-<td></td>
+<td class="signwriting">񃓱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1153,8 +1179,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00217.html">S169</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1162,8 +1188,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00024.html">S1e0</a></td>
-<td>񅐁</td>
-<td>񅐑</td>
+<td class="signwriting">񅐁</td>
+<td class="signwriting">񅐑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1171,8 +1197,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00059.html">S123</a></td>
-<td>񀴱</td>
-<td></td>
+<td class="signwriting">񀴱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1180,8 +1206,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00154.html">S1c3</a></td>
-<td>񄤱</td>
-<td></td>
+<td class="signwriting">񄤱</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00040.html
+++ b/inventories/inv00040.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>EthSL (SP_18)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>EthSL (SP_18)</h1>
@@ -55,8 +81,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00006.html">S1fb</a></td>
-<td>񅸱</td>
-<td></td>
+<td class="signwriting">񅸱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00134.html">S153</a></td>
-<td>񁼱</td>
-<td></td>
+<td class="signwriting">񁼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00204.html">S152</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00150.html">S18c</a></td>
-<td>񃒑</td>
-<td></td>
+<td class="signwriting">񃒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00005.html">S1f9</a></td>
-<td>񅵱</td>
-<td></td>
+<td class="signwriting">񅵱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00022.html">S1de</a></td>
-<td>񅍑</td>
-<td></td>
+<td class="signwriting">񅍑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00241.html">S19d</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00176.html">S113</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00152.html">S1da</a></td>
-<td>񅇑</td>
-<td></td>
+<td class="signwriting">񅇑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00262.html">S1c7</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00121.html">S128</a></td>
-<td>񀼑</td>
-<td></td>
+<td class="signwriting">񀼑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00267.html">S1cf</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00171.html">S107</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00139.html">S187</a></td>
-<td>񃊱</td>
-<td></td>
+<td class="signwriting">񃊱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00151.html">S18d</a></td>
-<td>񃓱</td>
-<td></td>
+<td class="signwriting">񃓱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00232.html">S186</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00054.html">S1a0</a></td>
-<td>񃰑</td>
-<td></td>
+<td class="signwriting">񃰑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00131.html">S17d</a></td>
-<td>񂻱</td>
-<td></td>
+<td class="signwriting">񂻱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00231.html">S184</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00023.html">S1df</a></td>
-<td>񅎱</td>
-<td></td>
+<td class="signwriting">񅎱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00127.html">S173</a></td>
-<td>񂬱</td>
-<td></td>
+<td class="signwriting">񂬱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00223.html">S175</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00194.html">S138</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00053.html">S19c</a></td>
-<td>񃪑</td>
-<td></td>
+<td class="signwriting">񃪑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00114.html">S129</a></td>
-<td>񀽱</td>
-<td></td>
+<td class="signwriting">񀽱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00169.html">S102</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00156.html">S1d2</a></td>
-<td>񄻑</td>
-<td></td>
+<td class="signwriting">񄻑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00173.html">S10d</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00115.html">S13d</a></td>
-<td>񁛡</td>
-<td>񁛱</td>
+<td class="signwriting">񁛡</td>
+<td class="signwriting">񁛱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00162.html">S10b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00019.html">S1ae</a></td>
-<td>񄅑</td>
-<td></td>
+<td class="signwriting">񄅑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -460,8 +486,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -469,8 +495,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00082.html">S14b</a></td>
-<td>񁰱</td>
-<td></td>
+<td class="signwriting">񁰱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -478,8 +504,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00055.html">S1b0</a></td>
-<td>񄈑</td>
-<td></td>
+<td class="signwriting">񄈑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -487,8 +513,8 @@
 <td>1fin_othersNonfist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00160.html">S105</a></td>
-<td>񀇱</td>
-<td></td>
+<td class="signwriting">񀇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -496,8 +522,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00251.html">S1b1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -505,8 +531,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00211.html">S162</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -514,8 +540,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00163.html">S14a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00041.html
+++ b/inventories/inv00041.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>FinSL (SP_57)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>FinSL (SP_57)</h1>
@@ -55,8 +81,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00083.html">S180</a></td>
-<td>񃀑</td>
-<td>񃀁</td>
+<td class="signwriting">񃀑</td>
+<td class="signwriting">񃀁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00166.html">S17e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00026.html">S1f2</a></td>
-<td>񅫁</td>
-<td></td>
+<td class="signwriting">񅫁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00267.html">S1cf</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00158.html">S1d4</a></td>
-<td>񄾑</td>
-<td></td>
+<td class="signwriting">񄾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00139.html">S187</a></td>
-<td>񃊱</td>
-<td></td>
+<td class="signwriting">񃊱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00205.html">S156</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00131.html">S17d</a></td>
-<td>񂻱</td>
-<td></td>
+<td class="signwriting">񂻱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00152.html">S1da</a></td>
-<td>񅇑</td>
-<td></td>
+<td class="signwriting">񅇑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00134.html">S153</a></td>
-<td>񁼱</td>
-<td></td>
+<td class="signwriting">񁼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00151.html">S18d</a></td>
-<td>񃓱</td>
-<td></td>
+<td class="signwriting">񃓱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00031.html">S1e1</a></td>
-<td>񅑱</td>
-<td>񅑡</td>
+<td class="signwriting">񅑱</td>
+<td class="signwriting">񅑡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00277.html">S1fa</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00163.html">S14a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00275.html">S1f1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00042.html
+++ b/inventories/inv00042.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>LSF (SP_58)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>LSF (SP_58)</h1>
@@ -55,8 +81,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00083.html">S180</a></td>
-<td>񃀑</td>
-<td>񃀁</td>
+<td class="signwriting">񃀑</td>
+<td class="signwriting">񃀁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00273.html">S1ec</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00158.html">S1d4</a></td>
-<td>񄾑</td>
-<td></td>
+<td class="signwriting">񄾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00043.html">S118</a></td>
-<td>񀤑</td>
-<td></td>
+<td class="signwriting">񀤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00131.html">S17d</a></td>
-<td>񂻱</td>
-<td></td>
+<td class="signwriting">񂻱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00113.html">S1f4</a></td>
-<td>񅮁</td>
-<td>񅮑</td>
+<td class="signwriting">񅮁</td>
+<td class="signwriting">񅮑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00108.html">S1ed</a></td>
-<td>񅣡</td>
-<td>񅢑</td>
+<td class="signwriting">񅣡</td>
+<td class="signwriting">񅢑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00121.html">S128</a></td>
-<td>񀼑</td>
-<td></td>
+<td class="signwriting">񀼑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00135.html">S154</a></td>
-<td>񁾑</td>
-<td></td>
+<td class="signwriting">񁾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00111.html">S1ee</a></td>
-<td>񅥑</td>
-<td></td>
+<td class="signwriting">񅥑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00130.html">S17c</a></td>
-<td>񂺑</td>
-<td></td>
+<td class="signwriting">񂺑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00134.html">S153</a></td>
-<td>񁼱</td>
-<td></td>
+<td class="signwriting">񁼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00103.html">S1c5</a></td>
-<td>񄧱</td>
-<td></td>
+<td class="signwriting">񄧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00065.html">S142</a></td>
-<td>񁣑</td>
-<td></td>
+<td class="signwriting">񁣑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00156.html">S1d2</a></td>
-<td>񄻑</td>
-<td></td>
+<td class="signwriting">񄻑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00114.html">S129</a></td>
-<td>񀽱</td>
-<td></td>
+<td class="signwriting">񀽱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00098.html">S14e</a></td>
-<td>񁵑</td>
-<td></td>
+<td class="signwriting">񁵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00209.html">S15f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00204.html">S152</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00155.html">S1d1</a></td>
-<td>񄹱</td>
-<td></td>
+<td class="signwriting">񄹱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00039.html">S119</a></td>
-<td>񀥱</td>
-<td></td>
+<td class="signwriting">񀥱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -460,8 +486,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00166.html">S17e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -469,8 +495,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -478,8 +504,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -487,8 +513,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00054.html">S1a0</a></td>
-<td>񃰑</td>
-<td></td>
+<td class="signwriting">񃰑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -496,8 +522,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -505,8 +531,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00144.html">S1bb</a></td>
-<td>񄘱</td>
-<td></td>
+<td class="signwriting">񄘱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -514,8 +540,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -523,8 +549,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00241.html">S19d</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -532,8 +558,8 @@
 <td>2finNonspread_othersFist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00118.html">S1a3</a></td>
-<td>񃴱</td>
-<td></td>
+<td class="signwriting">񃴱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -541,8 +567,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00254.html">S1b8</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -550,8 +576,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00174.html">S10f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -559,8 +585,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00097.html">S145</a></td>
-<td>񁧱</td>
-<td></td>
+<td class="signwriting">񁧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -568,8 +594,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -577,8 +603,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00157.html">S1d3</a></td>
-<td>񄼱</td>
-<td></td>
+<td class="signwriting">񄼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -586,8 +612,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00274.html">S1ef</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -595,8 +621,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00024.html">S1e0</a></td>
-<td>񅐁</td>
-<td>񅐑</td>
+<td class="signwriting">񅐁</td>
+<td class="signwriting">񅐑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -604,8 +630,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00086.html">S168</a></td>
-<td>񂜑</td>
-<td></td>
+<td class="signwriting">񂜑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -613,8 +639,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00163.html">S14a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -622,8 +648,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00265.html">S1ca</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -631,8 +657,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00205.html">S156</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -640,8 +666,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00116.html">S13f</a></td>
-<td>񁞱</td>
-<td></td>
+<td class="signwriting">񁞱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -649,8 +675,8 @@
 <td>4finSpread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00137.html">S155</a></td>
-<td>񁿱</td>
-<td></td>
+<td class="signwriting">񁿱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -658,8 +684,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00225.html">S179</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -667,8 +693,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00152.html">S1da</a></td>
-<td>񅇑</td>
-<td></td>
+<td class="signwriting">񅇑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -676,8 +702,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00062.html">S122</a></td>
-<td>񀳑</td>
-<td></td>
+<td class="signwriting">񀳑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -685,8 +711,8 @@
 <td>4finNonspread</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00133.html">S160</a></td>
-<td>񂐑</td>
-<td></td>
+<td class="signwriting">񂐑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -694,8 +720,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00053.html">S19c</a></td>
-<td>񃪑</td>
-<td></td>
+<td class="signwriting">񃪑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -703,8 +729,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00140.html">S18b</a></td>
-<td>񃐱</td>
-<td></td>
+<td class="signwriting">񃐱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -712,8 +738,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00023.html">S1df</a></td>
-<td>񅎱</td>
-<td></td>
+<td class="signwriting">񅎱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -721,8 +747,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00229.html">S181</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -730,8 +756,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00082.html">S14b</a></td>
-<td>񁰱</td>
-<td></td>
+<td class="signwriting">񁰱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -739,8 +765,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00232.html">S186</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -748,8 +774,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00151.html">S18d</a></td>
-<td>񃓱</td>
-<td></td>
+<td class="signwriting">񃓱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -757,8 +783,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00022.html">S1de</a></td>
-<td>񅍑</td>
-<td></td>
+<td class="signwriting">񅍑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -766,8 +792,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -775,8 +801,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00095.html">S158</a></td>
-<td>񂄑</td>
-<td></td>
+<td class="signwriting">񂄑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -784,8 +810,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00139.html">S187</a></td>
-<td>񃊱</td>
-<td></td>
+<td class="signwriting">񃊱</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00043.html
+++ b/inventories/inv00043.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>BSL (SP_59)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>BSL (SP_59)</h1>
@@ -55,8 +81,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00134.html">S153</a></td>
-<td>񁼱</td>
-<td></td>
+<td class="signwriting">񁼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00150.html">S18c</a></td>
-<td>񃒑</td>
-<td></td>
+<td class="signwriting">񃒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00103.html">S1c5</a></td>
-<td>񄧱</td>
-<td></td>
+<td class="signwriting">񄧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00108.html">S1ed</a></td>
-<td>񅣡</td>
-<td>񅢑</td>
+<td class="signwriting">񅣡</td>
+<td class="signwriting">񅢑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00113.html">S1f4</a></td>
-<td>񅮁</td>
-<td>񅮑</td>
+<td class="signwriting">񅮁</td>
+<td class="signwriting">񅮑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00083.html">S180</a></td>
-<td>񃀑</td>
-<td>񃀁</td>
+<td class="signwriting">񃀑</td>
+<td class="signwriting">񃀁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00043.html">S118</a></td>
-<td>񀤑</td>
-<td></td>
+<td class="signwriting">񀤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00098.html">S14e</a></td>
-<td>񁵑</td>
-<td></td>
+<td class="signwriting">񁵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00131.html">S17d</a></td>
-<td>񂻱</td>
-<td></td>
+<td class="signwriting">񂻱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00273.html">S1ec</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00162.html">S10b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00135.html">S154</a></td>
-<td>񁾑</td>
-<td></td>
+<td class="signwriting">񁾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00030.html">S198</a></td>
-<td>񃤑</td>
-<td></td>
+<td class="signwriting">񃤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00207.html">S15c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00232.html">S186</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00274.html">S1ef</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00130.html">S17c</a></td>
-<td>񂺑</td>
-<td></td>
+<td class="signwriting">񂺑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00269.html">S1db</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00204.html">S152</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00167.html">S1cd</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00202.html">S14f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00116.html">S13f</a></td>
-<td>񁞱</td>
-<td></td>
+<td class="signwriting">񁞱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -460,8 +486,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00025.html">S10c</a></td>
-<td>񀒑</td>
-<td></td>
+<td class="signwriting">񀒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -469,8 +495,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -478,8 +504,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00006.html">S1fb</a></td>
-<td>񅸱</td>
-<td></td>
+<td class="signwriting">񅸱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -487,8 +513,8 @@
 <td>3_nonspread</td>
 <td>extended</td>
 <td><a href="../segments/seg00066.html">S18e</a></td>
-<td>񃕑</td>
-<td></td>
+<td class="signwriting">񃕑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -496,8 +522,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -505,8 +531,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00158.html">S1d4</a></td>
-<td>񄾑</td>
-<td></td>
+<td class="signwriting">񄾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -514,8 +540,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00055.html">S1b0</a></td>
-<td>񄈑</td>
-<td></td>
+<td class="signwriting">񄈑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -523,8 +549,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -532,8 +558,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00039.html">S119</a></td>
-<td>񀥱</td>
-<td></td>
+<td class="signwriting">񀥱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -541,8 +567,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00140.html">S18b</a></td>
-<td>񃐱</td>
-<td></td>
+<td class="signwriting">񃐱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -550,8 +576,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -559,8 +585,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -568,8 +594,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00111.html">S1ee</a></td>
-<td>񅥑</td>
-<td></td>
+<td class="signwriting">񅥑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -577,8 +603,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00203.html">S151</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -586,8 +612,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00235.html">S18a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -595,8 +621,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00139.html">S187</a></td>
-<td>񃊱</td>
-<td></td>
+<td class="signwriting">񃊱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -604,8 +630,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00123.html">S12b</a></td>
-<td>񁀱</td>
-<td></td>
+<td class="signwriting">񁀱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -613,8 +639,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00151.html">S18d</a></td>
-<td>񃓱</td>
-<td></td>
+<td class="signwriting">񃓱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -622,8 +648,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00155.html">S1d1</a></td>
-<td>񄹱</td>
-<td></td>
+<td class="signwriting">񄹱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -631,8 +657,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00260.html">S1c0</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -640,8 +666,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00089.html">S171</a></td>
-<td>񂩱</td>
-<td></td>
+<td class="signwriting">񂩱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -649,8 +675,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00040.html">S132</a></td>
-<td>񁋑</td>
-<td></td>
+<td class="signwriting">񁋑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -658,8 +684,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00094.html">S146</a></td>
-<td>񁩑</td>
-<td></td>
+<td class="signwriting">񁩑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -667,8 +693,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00095.html">S158</a></td>
-<td>񂄑</td>
-<td></td>
+<td class="signwriting">񂄑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -676,8 +702,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00101.html">S157</a></td>
-<td>񂂱</td>
-<td></td>
+<td class="signwriting">񂂱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -685,8 +711,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00058.html">S112</a></td>
-<td>񀛑</td>
-<td></td>
+<td class="signwriting">񀛑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -694,8 +720,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00097.html">S145</a></td>
-<td>񁧱</td>
-<td></td>
+<td class="signwriting">񁧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -703,8 +729,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00152.html">S1da</a></td>
-<td>񅇑</td>
-<td></td>
+<td class="signwriting">񅇑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -712,8 +738,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00153.html">S1c1</a></td>
-<td>񄡱</td>
-<td></td>
+<td class="signwriting">񄡱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -721,8 +747,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00144.html">S1bb</a></td>
-<td>񄘱</td>
-<td></td>
+<td class="signwriting">񄘱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -730,8 +756,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00211.html">S162</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -739,8 +765,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00022.html">S1de</a></td>
-<td>񅍑</td>
-<td></td>
+<td class="signwriting">񅍑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -748,8 +774,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00003.html">S1f8</a></td>
-<td>񅴑</td>
-<td></td>
+<td class="signwriting">񅴑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -757,8 +783,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00005.html">S1f9</a></td>
-<td>񅵱</td>
-<td></td>
+<td class="signwriting">񅵱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -766,8 +792,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00271.html">S1e6</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -775,8 +801,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -784,8 +810,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00245.html">S1a6</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -793,8 +819,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00277.html">S1fa</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -802,8 +828,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -811,8 +837,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00146.html">S1d0</a></td>
-<td>񄸑</td>
-<td></td>
+<td class="signwriting">񄸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -820,8 +846,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00220.html">S16c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -829,8 +855,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00189.html">S133</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -838,8 +864,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00233.html">S188</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -847,8 +873,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00007.html">S1fc</a></td>
-<td>񅺡</td>
-<td>񅺑</td>
+<td class="signwriting">񅺡</td>
+<td class="signwriting">񅺑</td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00044.html
+++ b/inventories/inv00044.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>NISLs (SP_60)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>NISLs (SP_60)</h1>
@@ -55,8 +81,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00043.html">S118</a></td>
-<td>񀤑</td>
-<td></td>
+<td class="signwriting">񀤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00020.html">S1c6</a></td>
-<td>񄩁</td>
-<td>񄩑</td>
+<td class="signwriting">񄩁</td>
+<td class="signwriting">񄩑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>3_nonspread</td>
 <td>extended</td>
 <td><a href="../segments/seg00066.html">S18e</a></td>
-<td>񃕑</td>
-<td></td>
+<td class="signwriting">񃕑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00167.html">S1cd</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00130.html">S17c</a></td>
-<td>񂺑</td>
-<td></td>
+<td class="signwriting">񂺑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00055.html">S1b0</a></td>
-<td>񄈑</td>
-<td></td>
+<td class="signwriting">񄈑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00022.html">S1de</a></td>
-<td>񅍑</td>
-<td></td>
+<td class="signwriting">񅍑</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00045.html
+++ b/inventories/inv00045.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ENG (SP_61)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>ENG (SP_61)</h1>
@@ -55,8 +81,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00054.html">S1a0</a></td>
-<td>񃰑</td>
-<td></td>
+<td class="signwriting">񃰑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00159.html">S1d8</a></td>
-<td>񅄑</td>
-<td></td>
+<td class="signwriting">񅄑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00150.html">S18c</a></td>
-<td>񃒑</td>
-<td></td>
+<td class="signwriting">񃒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00048.html">S11d</a></td>
-<td>񀫡</td>
-<td></td>
+<td class="signwriting">񀫡</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00105.html">S1e5</a></td>
-<td>񅗱</td>
-<td></td>
+<td class="signwriting">񅗱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00163.html">S14a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>1fin_othersNonfist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00160.html">S105</a></td>
-<td>񀇱</td>
-<td></td>
+<td class="signwriting">񀇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00046.html
+++ b/inventories/inv00046.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Lensegua (SP_112)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Lensegua (SP_112)</h1>
@@ -55,8 +81,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00047.html
+++ b/inventories/inv00047.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>HKSL (SP_12)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>HKSL (SP_12)</h1>
@@ -55,8 +81,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00048.html
+++ b/inventories/inv00048.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>LESHO (SP_16)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>LESHO (SP_16)</h1>
@@ -55,8 +81,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00163.html">S14a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00039.html">S119</a></td>
-<td>񀥱</td>
-<td></td>
+<td class="signwriting">񀥱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00151.html">S18d</a></td>
-<td>񃓱</td>
-<td></td>
+<td class="signwriting">񃓱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00135.html">S154</a></td>
-<td>񁾑</td>
-<td></td>
+<td class="signwriting">񁾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00220.html">S16c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00229.html">S181</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00134.html">S153</a></td>
-<td>񁼱</td>
-<td></td>
+<td class="signwriting">񁼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00083.html">S180</a></td>
-<td>񃀑</td>
-<td>񃀁</td>
+<td class="signwriting">񃀑</td>
+<td class="signwriting">񃀁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00144.html">S1bb</a></td>
-<td>񄘱</td>
-<td></td>
+<td class="signwriting">񄘱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00158.html">S1d4</a></td>
-<td>񄾑</td>
-<td></td>
+<td class="signwriting">񄾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00139.html">S187</a></td>
-<td>񃊱</td>
-<td></td>
+<td class="signwriting">񃊱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00098.html">S14e</a></td>
-<td>񁵑</td>
-<td></td>
+<td class="signwriting">񁵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00043.html">S118</a></td>
-<td>񀤑</td>
-<td></td>
+<td class="signwriting">񀤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00103.html">S1c5</a></td>
-<td>񄧱</td>
-<td></td>
+<td class="signwriting">񄧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00166.html">S17e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00156.html">S1d2</a></td>
-<td>񄻑</td>
-<td></td>
+<td class="signwriting">񄻑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00275.html">S1f1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -460,8 +486,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00082.html">S14b</a></td>
-<td>񁰱</td>
-<td></td>
+<td class="signwriting">񁰱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -469,8 +495,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00142.html">S1a5</a></td>
-<td>񃷱</td>
-<td></td>
+<td class="signwriting">񃷱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -478,8 +504,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00003.html">S1f8</a></td>
-<td>񅴑</td>
-<td></td>
+<td class="signwriting">񅴑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -487,8 +513,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00131.html">S17d</a></td>
-<td>񂻱</td>
-<td></td>
+<td class="signwriting">񂻱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -496,8 +522,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00101.html">S157</a></td>
-<td>񂂱</td>
-<td></td>
+<td class="signwriting">񂂱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -505,8 +531,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00108.html">S1ed</a></td>
-<td>񅣡</td>
-<td>񅢑</td>
+<td class="signwriting">񅣡</td>
+<td class="signwriting">񅢑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -514,8 +540,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -523,8 +549,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -532,8 +558,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00157.html">S1d3</a></td>
-<td>񄼱</td>
-<td></td>
+<td class="signwriting">񄼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -541,8 +567,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00127.html">S173</a></td>
-<td>񂬱</td>
-<td></td>
+<td class="signwriting">񂬱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -550,8 +576,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00113.html">S1f4</a></td>
-<td>񅮁</td>
-<td>񅮑</td>
+<td class="signwriting">񅮁</td>
+<td class="signwriting">񅮑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -559,8 +585,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00130.html">S17c</a></td>
-<td>񂺑</td>
-<td></td>
+<td class="signwriting">񂺑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -568,8 +594,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00111.html">S1ee</a></td>
-<td>񅥑</td>
-<td></td>
+<td class="signwriting">񅥑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -577,8 +603,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00205.html">S156</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -586,8 +612,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -595,8 +621,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00162.html">S10b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -604,8 +630,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00054.html">S1a0</a></td>
-<td>񃰑</td>
-<td></td>
+<td class="signwriting">񃰑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -613,8 +639,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00227.html">S17b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -622,8 +648,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00022.html">S1de</a></td>
-<td>񅍑</td>
-<td></td>
+<td class="signwriting">񅍑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -631,8 +657,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00062.html">S122</a></td>
-<td>񀳑</td>
-<td></td>
+<td class="signwriting">񀳑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -640,8 +666,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00271.html">S1e6</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -649,8 +675,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00228.html">S17f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -658,8 +684,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00065.html">S142</a></td>
-<td>񁣑</td>
-<td></td>
+<td class="signwriting">񁣑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -667,8 +693,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00155.html">S1d1</a></td>
-<td>񄹱</td>
-<td></td>
+<td class="signwriting">񄹱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -676,8 +702,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00031.html">S1e1</a></td>
-<td>񅑱</td>
-<td>񅑡</td>
+<td class="signwriting">񅑱</td>
+<td class="signwriting">񅑡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -685,8 +711,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00224.html">S178</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -694,8 +720,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00116.html">S13f</a></td>
-<td>񁞱</td>
-<td></td>
+<td class="signwriting">񁞱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -703,8 +729,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00203.html">S151</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -712,8 +738,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00274.html">S1ef</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -721,8 +747,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00221.html">S172</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -730,8 +756,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00209.html">S15f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -739,8 +765,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00273.html">S1ec</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -748,8 +774,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00088.html">S170</a></td>
-<td>񂨑</td>
-<td></td>
+<td class="signwriting">񂨑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -757,8 +783,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00226.html">S17a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -766,8 +792,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00204.html">S152</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -775,8 +801,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00150.html">S18c</a></td>
-<td>񃒑</td>
-<td></td>
+<td class="signwriting">񃒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -784,8 +810,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00121.html">S128</a></td>
-<td>񀼑</td>
-<td></td>
+<td class="signwriting">񀼑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -793,8 +819,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00152.html">S1da</a></td>
-<td>񅇑</td>
-<td></td>
+<td class="signwriting">񅇑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -802,8 +828,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00206.html">S15b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -811,8 +837,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00025.html">S10c</a></td>
-<td>񀒑</td>
-<td></td>
+<td class="signwriting">񀒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -820,8 +846,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00095.html">S158</a></td>
-<td>񂄑</td>
-<td></td>
+<td class="signwriting">񂄑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -829,8 +855,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00115.html">S13d</a></td>
-<td>񁛡</td>
-<td>񁛱</td>
+<td class="signwriting">񁛡</td>
+<td class="signwriting">񁛱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -838,8 +864,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00089.html">S171</a></td>
-<td>񂩱</td>
-<td></td>
+<td class="signwriting">񂩱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -847,8 +873,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00153.html">S1c1</a></td>
-<td>񄡱</td>
-<td></td>
+<td class="signwriting">񄡱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -856,8 +882,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00146.html">S1d0</a></td>
-<td>񄸑</td>
-<td></td>
+<td class="signwriting">񄸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -865,8 +891,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00097.html">S145</a></td>
-<td>񁧱</td>
-<td></td>
+<td class="signwriting">񁧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -874,8 +900,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00174.html">S10f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -883,8 +909,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00147.html">S1d5</a></td>
-<td>񄿱</td>
-<td></td>
+<td class="signwriting">񄿱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -892,8 +918,8 @@
 <td>4finNonspread</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00133.html">S160</a></td>
-<td>񂐑</td>
-<td></td>
+<td class="signwriting">񂐑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -901,8 +927,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00105.html">S1e5</a></td>
-<td>񅗱</td>
-<td></td>
+<td class="signwriting">񅗱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -910,8 +936,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00233.html">S188</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -919,8 +945,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00215.html">S166</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -928,8 +954,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00165.html">S16f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -937,8 +963,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00232.html">S186</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -946,8 +972,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00005.html">S1f9</a></td>
-<td>񅵱</td>
-<td></td>
+<td class="signwriting">񅵱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -955,8 +981,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00164.html">S14d</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -964,8 +990,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00222.html">S174</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -973,8 +999,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00179.html">S11b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -982,8 +1008,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00085.html">S149</a></td>
-<td>񁭱</td>
-<td></td>
+<td class="signwriting">񁭱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -991,8 +1017,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00235.html">S18a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1000,8 +1026,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00225.html">S179</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1009,8 +1035,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00202.html">S14f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1018,8 +1044,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00123.html">S12b</a></td>
-<td>񁀱</td>
-<td></td>
+<td class="signwriting">񁀱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1027,8 +1053,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00086.html">S168</a></td>
-<td>񂜑</td>
-<td></td>
+<td class="signwriting">񂜑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1036,8 +1062,8 @@
 <td>4finSpread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00137.html">S155</a></td>
-<td>񁿱</td>
-<td></td>
+<td class="signwriting">񁿱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1045,8 +1071,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00201.html">S148</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1054,8 +1080,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00026.html">S1f2</a></td>
-<td>񅫁</td>
-<td></td>
+<td class="signwriting">񅫁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1063,8 +1089,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00006.html">S1fb</a></td>
-<td>񅸱</td>
-<td></td>
+<td class="signwriting">񅸱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1072,8 +1098,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00053.html">S19c</a></td>
-<td>񃪑</td>
-<td></td>
+<td class="signwriting">񃪑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1081,8 +1107,8 @@
 <td>3_spread</td>
 <td>extended</td>
 <td><a href="../segments/seg00071.html">S18f</a></td>
-<td>񃖱</td>
-<td></td>
+<td class="signwriting">񃖱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1090,8 +1116,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00172.html">S109</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1099,8 +1125,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00032.html">S1e2</a></td>
-<td>񅓁</td>
-<td></td>
+<td class="signwriting">񅓁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1108,8 +1134,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00143.html">S1ba</a></td>
-<td>񄗁</td>
-<td></td>
+<td class="signwriting">񄗁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1117,8 +1143,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00277.html">S1fa</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1126,8 +1152,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00114.html">S129</a></td>
-<td>񀽱</td>
-<td></td>
+<td class="signwriting">񀽱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1135,8 +1161,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00241.html">S19d</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1144,8 +1170,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00096.html">S159</a></td>
-<td>񂅱</td>
-<td></td>
+<td class="signwriting">񂅱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1153,8 +1179,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00199.html">S141</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1162,8 +1188,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00278.html">S1fe</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1171,8 +1197,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00270.html">S1e3</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1180,8 +1206,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00234.html">S189</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1189,8 +1215,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00177.html">S114</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1198,8 +1224,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00171.html">S107</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1207,8 +1233,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00243.html">S1a1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1216,8 +1242,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00219.html">S16b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1225,8 +1251,8 @@
 <td>2finNonspread_othersFist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00118.html">S1a3</a></td>
-<td>񃴱</td>
-<td></td>
+<td class="signwriting">񃴱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1234,8 +1260,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00040.html">S132</a></td>
-<td>񁋑</td>
-<td></td>
+<td class="signwriting">񁋑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1243,8 +1269,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00272.html">S1e8</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1252,8 +1278,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00046.html">S116</a></td>
-<td>񀡑</td>
-<td></td>
+<td class="signwriting">񀡑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1261,8 +1287,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00094.html">S146</a></td>
-<td>񁩑</td>
-<td></td>
+<td class="signwriting">񁩑</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00049.html
+++ b/inventories/inv00049.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>LSH (SP_113)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>LSH (SP_113)</h1>
@@ -55,8 +81,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00050.html
+++ b/inventories/inv00050.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>HSL (SP_122)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>HSL (SP_122)</h1>
@@ -55,8 +81,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00152.html">S1da</a></td>
-<td>񅇑</td>
-<td></td>
+<td class="signwriting">񅇑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00214.html">S165</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00098.html">S14e</a></td>
-<td>񁵑</td>
-<td></td>
+<td class="signwriting">񁵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00219.html">S16b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00043.html">S118</a></td>
-<td>񀤑</td>
-<td></td>
+<td class="signwriting">񀤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00025.html">S10c</a></td>
-<td>񀒑</td>
-<td></td>
+<td class="signwriting">񀒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00087.html">S16e</a></td>
-<td>񂥑</td>
-<td></td>
+<td class="signwriting">񂥑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00176.html">S113</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00051.html
+++ b/inventories/inv00051.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ISL (IE) (SP_62)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>ISL (IE) (SP_62)</h1>
@@ -55,8 +81,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00115.html">S13d</a></td>
-<td>񁛡</td>
-<td>񁛱</td>
+<td class="signwriting">񁛡</td>
+<td class="signwriting">񁛱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00116.html">S13f</a></td>
-<td>񁞱</td>
-<td></td>
+<td class="signwriting">񁞱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00150.html">S18c</a></td>
-<td>񃒑</td>
-<td></td>
+<td class="signwriting">񃒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00039.html">S119</a></td>
-<td>񀥱</td>
-<td></td>
+<td class="signwriting">񀥱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00158.html">S1d4</a></td>
-<td>񄾑</td>
-<td></td>
+<td class="signwriting">񄾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00151.html">S18d</a></td>
-<td>񃓱</td>
-<td></td>
+<td class="signwriting">񃓱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00142.html">S1a5</a></td>
-<td>񃷱</td>
-<td></td>
+<td class="signwriting">񃷱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00167.html">S1cd</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00278.html">S1fe</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00232.html">S186</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00144.html">S1bb</a></td>
-<td>񄘱</td>
-<td></td>
+<td class="signwriting">񄘱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00043.html">S118</a></td>
-<td>񀤑</td>
-<td></td>
+<td class="signwriting">񀤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00162.html">S10b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00022.html">S1de</a></td>
-<td>񅍑</td>
-<td></td>
+<td class="signwriting">񅍑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00237.html">S194</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00054.html">S1a0</a></td>
-<td>񃰑</td>
-<td></td>
+<td class="signwriting">񃰑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00156.html">S1d2</a></td>
-<td>񄻑</td>
-<td></td>
+<td class="signwriting">񄻑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00163.html">S14a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00052.html
+++ b/inventories/inv00052.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Shassi, ISL (SP_110)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Shassi, ISL (SP_110)</h1>
@@ -55,8 +81,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00089.html">S171</a></td>
-<td>񂩱</td>
-<td></td>
+<td class="signwriting">񂩱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00205.html">S156</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00156.html">S1d2</a></td>
-<td>񄻑</td>
-<td></td>
+<td class="signwriting">񄻑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00007.html">S1fc</a></td>
-<td>񅺡</td>
-<td>񅺑</td>
+<td class="signwriting">񅺡</td>
+<td class="signwriting">񅺑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00008.html">S1fd</a></td>
-<td>񅼁</td>
-<td>񅻱</td>
+<td class="signwriting">񅼁</td>
+<td class="signwriting">񅻱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00054.html">S1a0</a></td>
-<td>񃰑</td>
-<td></td>
+<td class="signwriting">񃰑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>1fin_othersNonfist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00160.html">S105</a></td>
-<td>񀇱</td>
-<td></td>
+<td class="signwriting">񀇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00270.html">S1e3</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00053.html
+++ b/inventories/inv00053.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ISL (IN) (SP_85)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>ISL (IN) (SP_85)</h1>
@@ -55,8 +81,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00054.html
+++ b/inventories/inv00054.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ÍTM (SP_131)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>ÍTM (SP_131)</h1>
@@ -55,8 +81,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00101.html">S157</a></td>
-<td>񂂱</td>
-<td></td>
+<td class="signwriting">񂂱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00089.html">S171</a></td>
-<td>񂩱</td>
-<td></td>
+<td class="signwriting">񂩱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00039.html">S119</a></td>
-<td>񀥱</td>
-<td></td>
+<td class="signwriting">񀥱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00055.html
+++ b/inventories/inv00055.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>LIS (SP_63)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>LIS (SP_63)</h1>
@@ -55,8 +81,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00162.html">S10b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00134.html">S153</a></td>
-<td>񁼱</td>
-<td></td>
+<td class="signwriting">񁼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00135.html">S154</a></td>
-<td>񁾑</td>
-<td></td>
+<td class="signwriting">񁾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00108.html">S1ed</a></td>
-<td>񅣡</td>
-<td>񅢑</td>
+<td class="signwriting">񅣡</td>
+<td class="signwriting">񅢑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00158.html">S1d4</a></td>
-<td>񄾑</td>
-<td></td>
+<td class="signwriting">񄾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00083.html">S180</a></td>
-<td>񃀑</td>
-<td>񃀁</td>
+<td class="signwriting">񃀑</td>
+<td class="signwriting">񃀁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00043.html">S118</a></td>
-<td>񀤑</td>
-<td></td>
+<td class="signwriting">񀤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00101.html">S157</a></td>
-<td>񂂱</td>
-<td></td>
+<td class="signwriting">񂂱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00223.html">S175</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00228.html">S17f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00039.html">S119</a></td>
-<td>񀥱</td>
-<td></td>
+<td class="signwriting">񀥱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00022.html">S1de</a></td>
-<td>񅍑</td>
-<td></td>
+<td class="signwriting">񅍑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00058.html">S112</a></td>
-<td>񀛑</td>
-<td></td>
+<td class="signwriting">񀛑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td>4finSpread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00137.html">S155</a></td>
-<td>񁿱</td>
-<td></td>
+<td class="signwriting">񁿱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00087.html">S16e</a></td>
-<td>񂥑</td>
-<td></td>
+<td class="signwriting">񂥑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00103.html">S1c5</a></td>
-<td>񄧱</td>
-<td></td>
+<td class="signwriting">񄧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00025.html">S10c</a></td>
-<td>񀒑</td>
-<td></td>
+<td class="signwriting">񀒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00111.html">S1ee</a></td>
-<td>񅥑</td>
-<td></td>
+<td class="signwriting">񅥑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00106.html">S1e7</a></td>
-<td>񅚱</td>
-<td></td>
+<td class="signwriting">񅚱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00224.html">S178</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00054.html">S1a0</a></td>
-<td>񃰑</td>
-<td></td>
+<td class="signwriting">񃰑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00116.html">S13f</a></td>
-<td>񁞱</td>
-<td></td>
+<td class="signwriting">񁞱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00229.html">S181</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -460,8 +486,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -469,8 +495,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00204.html">S152</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -478,8 +504,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00113.html">S1f4</a></td>
-<td>񅮁</td>
-<td>񅮑</td>
+<td class="signwriting">񅮁</td>
+<td class="signwriting">񅮑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -487,8 +513,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00121.html">S128</a></td>
-<td>񀼑</td>
-<td></td>
+<td class="signwriting">񀼑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -496,8 +522,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00110.html">S1e4</a></td>
-<td>񅖑</td>
-<td></td>
+<td class="signwriting">񅖑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -505,8 +531,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00166.html">S17e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -514,8 +540,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00155.html">S1d1</a></td>
-<td>񄹱</td>
-<td></td>
+<td class="signwriting">񄹱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -523,8 +549,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00097.html">S145</a></td>
-<td>񁧱</td>
-<td></td>
+<td class="signwriting">񁧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -532,8 +558,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00222.html">S174</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -541,8 +567,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00026.html">S1f2</a></td>
-<td>񅫁</td>
-<td></td>
+<td class="signwriting">񅫁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -550,8 +576,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00163.html">S14a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -559,8 +585,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00082.html">S14b</a></td>
-<td>񁰱</td>
-<td></td>
+<td class="signwriting">񁰱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -568,8 +594,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00256.html">S1bc</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -577,8 +603,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -586,8 +612,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -595,8 +621,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00094.html">S146</a></td>
-<td>񁩑</td>
-<td></td>
+<td class="signwriting">񁩑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -604,8 +630,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00164.html">S14d</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -613,8 +639,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00220.html">S16c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -622,8 +648,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00003.html">S1f8</a></td>
-<td>񅴑</td>
-<td></td>
+<td class="signwriting">񅴑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -631,8 +657,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00159.html">S1d8</a></td>
-<td>񅄑</td>
-<td></td>
+<td class="signwriting">񅄑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -640,8 +666,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00267.html">S1cf</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -649,8 +675,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00273.html">S1ec</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -658,8 +684,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00261.html">S1c2</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -667,8 +693,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00203.html">S151</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -676,8 +702,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00122.html">S12a</a></td>
-<td>񀿑</td>
-<td></td>
+<td class="signwriting">񀿑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -685,8 +711,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00098.html">S14e</a></td>
-<td>񁵑</td>
-<td></td>
+<td class="signwriting">񁵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -694,8 +720,8 @@
 <td>1fin_othersNonfist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00160.html">S105</a></td>
-<td>񀇱</td>
-<td></td>
+<td class="signwriting">񀇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -703,8 +729,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00006.html">S1fb</a></td>
-<td>񅸱</td>
-<td></td>
+<td class="signwriting">񅸱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -712,8 +738,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00139.html">S187</a></td>
-<td>񃊱</td>
-<td></td>
+<td class="signwriting">񃊱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -721,8 +747,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00151.html">S18d</a></td>
-<td>񃓱</td>
-<td></td>
+<td class="signwriting">񃓱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -730,8 +756,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00274.html">S1ef</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -739,8 +765,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00275.html">S1f1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -748,8 +774,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -757,8 +783,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00088.html">S170</a></td>
-<td>񂨑</td>
-<td></td>
+<td class="signwriting">񂨑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -766,8 +792,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00031.html">S1e1</a></td>
-<td>񅑱</td>
-<td>񅑡</td>
+<td class="signwriting">񅑱</td>
+<td class="signwriting">񅑡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -775,8 +801,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00268.html">S1d9</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -784,8 +810,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00277.html">S1fa</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -793,8 +819,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00048.html">S11d</a></td>
-<td>񀫡</td>
-<td></td>
+<td class="signwriting">񀫡</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -802,8 +828,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00232.html">S186</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -811,8 +837,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00053.html">S19c</a></td>
-<td>񃪑</td>
-<td></td>
+<td class="signwriting">񃪑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -820,8 +846,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00270.html">S1e3</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -829,8 +855,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00167.html">S1cd</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -838,8 +864,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00085.html">S149</a></td>
-<td>񁭱</td>
-<td></td>
+<td class="signwriting">񁭱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -847,8 +873,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00056.html
+++ b/inventories/inv00056.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>LIU (SP_86)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>LIU (SP_86)</h1>
@@ -55,8 +81,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00098.html">S14e</a></td>
-<td>񁵑</td>
-<td></td>
+<td class="signwriting">񁵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00273.html">S1ec</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00114.html">S129</a></td>
-<td>񀽱</td>
-<td></td>
+<td class="signwriting">񀽱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>1fin_othersNonfist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00160.html">S105</a></td>
-<td>񀇱</td>
-<td></td>
+<td class="signwriting">񀇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00264.html">S1c9</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00057.html
+++ b/inventories/inv00057.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>JSL (SP_64)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>JSL (SP_64)</h1>
@@ -55,8 +81,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00020.html">S1c6</a></td>
-<td>񄩁</td>
-<td>񄩑</td>
+<td class="signwriting">񄩁</td>
+<td class="signwriting">񄩑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00232.html">S186</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00229.html">S181</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>2finNonspread_othersFist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00118.html">S1a3</a></td>
-<td>񃴱</td>
-<td></td>
+<td class="signwriting">񃴱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00083.html">S180</a></td>
-<td>񃀑</td>
-<td>񃀁</td>
+<td class="signwriting">񃀑</td>
+<td class="signwriting">񃀁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>2finNonspread_othersFist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00120.html">S1b3</a></td>
-<td>񄌱</td>
-<td></td>
+<td class="signwriting">񄌱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00150.html">S18c</a></td>
-<td>񃒑</td>
-<td></td>
+<td class="signwriting">񃒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00135.html">S154</a></td>
-<td>񁾑</td>
-<td></td>
+<td class="signwriting">񁾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>1fin_othersNonfist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00161.html">S196</a></td>
-<td>񃡑</td>
-<td></td>
+<td class="signwriting">񃡑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00113.html">S1f4</a></td>
-<td>񅮁</td>
-<td>񅮑</td>
+<td class="signwriting">񅮁</td>
+<td class="signwriting">񅮑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00103.html">S1c5</a></td>
-<td>񄧱</td>
-<td></td>
+<td class="signwriting">񄧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00151.html">S18d</a></td>
-<td>񃓱</td>
-<td></td>
+<td class="signwriting">񃓱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00215.html">S166</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00228.html">S17f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00162.html">S10b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00144.html">S1bb</a></td>
-<td>񄘱</td>
-<td></td>
+<td class="signwriting">񄘱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00273.html">S1ec</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00110.html">S1e4</a></td>
-<td>񅖑</td>
-<td></td>
+<td class="signwriting">񅖑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -460,8 +486,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00089.html">S171</a></td>
-<td>񂩱</td>
-<td></td>
+<td class="signwriting">񂩱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -469,8 +495,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00163.html">S14a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -478,8 +504,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00025.html">S10c</a></td>
-<td>񀒑</td>
-<td></td>
+<td class="signwriting">񀒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -487,8 +513,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00158.html">S1d4</a></td>
-<td>񄾑</td>
-<td></td>
+<td class="signwriting">񄾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -496,8 +522,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -505,8 +531,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00111.html">S1ee</a></td>
-<td>񅥑</td>
-<td></td>
+<td class="signwriting">񅥑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -514,8 +540,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00005.html">S1f9</a></td>
-<td>񅵱</td>
-<td></td>
+<td class="signwriting">񅵱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -523,8 +549,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00030.html">S198</a></td>
-<td>񃤑</td>
-<td></td>
+<td class="signwriting">񃤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -532,8 +558,8 @@
 <td>3_nonspread</td>
 <td>extended</td>
 <td><a href="../segments/seg00066.html">S18e</a></td>
-<td>񃕑</td>
-<td></td>
+<td class="signwriting">񃕑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -541,8 +567,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00108.html">S1ed</a></td>
-<td>񅣡</td>
-<td>񅢑</td>
+<td class="signwriting">񅣡</td>
+<td class="signwriting">񅢑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -550,8 +576,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00043.html">S118</a></td>
-<td>񀤑</td>
-<td></td>
+<td class="signwriting">񀤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -559,8 +585,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00267.html">S1cf</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -568,8 +594,8 @@
 <td>4finSpread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00137.html">S155</a></td>
-<td>񁿱</td>
-<td></td>
+<td class="signwriting">񁿱</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00058.html
+++ b/inventories/inv00058.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>KSL, LAK (SP_79)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>KSL, LAK (SP_79)</h1>
@@ -55,8 +81,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00165.html">S16f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00159.html">S1d8</a></td>
-<td>񅄑</td>
-<td></td>
+<td class="signwriting">񅄑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00089.html">S171</a></td>
-<td>񂩱</td>
-<td></td>
+<td class="signwriting">񂩱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00065.html">S142</a></td>
-<td>񁣑</td>
-<td></td>
+<td class="signwriting">񁣑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00113.html">S1f4</a></td>
-<td>񅮁</td>
-<td>񅮑</td>
+<td class="signwriting">񅮁</td>
+<td class="signwriting">񅮑</td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00059.html
+++ b/inventories/inv00059.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>KSL (SP_78)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>KSL (SP_78)</h1>
@@ -55,8 +81,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00098.html">S14e</a></td>
-<td>񁵑</td>
-<td></td>
+<td class="signwriting">񁵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00108.html">S1ed</a></td>
-<td>񅣡</td>
-<td>񅢑</td>
+<td class="signwriting">񅣡</td>
+<td class="signwriting">񅢑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00043.html">S118</a></td>
-<td>񀤑</td>
-<td></td>
+<td class="signwriting">񀤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00135.html">S154</a></td>
-<td>񁾑</td>
-<td></td>
+<td class="signwriting">񁾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00220.html">S16c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00083.html">S180</a></td>
-<td>񃀑</td>
-<td>񃀁</td>
+<td class="signwriting">񃀑</td>
+<td class="signwriting">񃀁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>4finSpread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00137.html">S155</a></td>
-<td>񁿱</td>
-<td></td>
+<td class="signwriting">񁿱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00113.html">S1f4</a></td>
-<td>񅮁</td>
-<td>񅮑</td>
+<td class="signwriting">񅮁</td>
+<td class="signwriting">񅮑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00131.html">S17d</a></td>
-<td>񂻱</td>
-<td></td>
+<td class="signwriting">񂻱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00162.html">S10b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00003.html">S1f8</a></td>
-<td>񅴑</td>
-<td></td>
+<td class="signwriting">񅴑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00046.html">S116</a></td>
-<td>񀡑</td>
-<td></td>
+<td class="signwriting">񀡑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00144.html">S1bb</a></td>
-<td>񄘱</td>
-<td></td>
+<td class="signwriting">񄘱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00228.html">S17f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00134.html">S153</a></td>
-<td>񁼱</td>
-<td></td>
+<td class="signwriting">񁼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00166.html">S17e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00111.html">S1ee</a></td>
-<td>񅥑</td>
-<td></td>
+<td class="signwriting">񅥑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00101.html">S157</a></td>
-<td>񂂱</td>
-<td></td>
+<td class="signwriting">񂂱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00087.html">S16e</a></td>
-<td>񂥑</td>
-<td></td>
+<td class="signwriting">񂥑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00130.html">S17c</a></td>
-<td>񂺑</td>
-<td></td>
+<td class="signwriting">񂺑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00202.html">S14f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00103.html">S1c5</a></td>
-<td>񄧱</td>
-<td></td>
+<td class="signwriting">񄧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -460,8 +486,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -469,8 +495,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -478,8 +504,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00275.html">S1f1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -487,8 +513,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00031.html">S1e1</a></td>
-<td>񅑱</td>
-<td>񅑡</td>
+<td class="signwriting">񅑱</td>
+<td class="signwriting">񅑡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -496,8 +522,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00172.html">S109</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -505,8 +531,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00229.html">S181</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -514,8 +540,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00054.html">S1a0</a></td>
-<td>񃰑</td>
-<td></td>
+<td class="signwriting">񃰑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -523,8 +549,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00232.html">S186</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -532,8 +558,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00224.html">S178</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -541,8 +567,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00221.html">S172</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -550,8 +576,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00203.html">S151</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -559,8 +585,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00022.html">S1de</a></td>
-<td>񅍑</td>
-<td></td>
+<td class="signwriting">񅍑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -568,8 +594,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00165.html">S16f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -577,8 +603,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -586,8 +612,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00025.html">S10c</a></td>
-<td>񀒑</td>
-<td></td>
+<td class="signwriting">񀒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -595,8 +621,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00205.html">S156</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -604,8 +630,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00273.html">S1ec</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -613,8 +639,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00204.html">S152</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -622,8 +648,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00009.html">S1ff</a></td>
-<td>񅾱</td>
-<td></td>
+<td class="signwriting">񅾱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -631,8 +657,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00175.html">S111</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -640,8 +666,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00164.html">S14d</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -649,8 +675,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00274.html">S1ef</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -658,8 +684,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00053.html">S19c</a></td>
-<td>񃪑</td>
-<td></td>
+<td class="signwriting">񃪑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -667,8 +693,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00039.html">S119</a></td>
-<td>񀥱</td>
-<td></td>
+<td class="signwriting">񀥱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -676,8 +702,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00110.html">S1e4</a></td>
-<td>񅖑</td>
-<td></td>
+<td class="signwriting">񅖑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -685,8 +711,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00030.html">S198</a></td>
-<td>񃤑</td>
-<td></td>
+<td class="signwriting">񃤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -694,8 +720,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00146.html">S1d0</a></td>
-<td>񄸑</td>
-<td></td>
+<td class="signwriting">񄸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -703,8 +729,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00227.html">S17b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -712,8 +738,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00153.html">S1c1</a></td>
-<td>񄡱</td>
-<td></td>
+<td class="signwriting">񄡱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -721,8 +747,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00095.html">S158</a></td>
-<td>񂄑</td>
-<td></td>
+<td class="signwriting">񂄑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -730,8 +756,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00140.html">S18b</a></td>
-<td>񃐱</td>
-<td></td>
+<td class="signwriting">񃐱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -739,8 +765,8 @@
 <td>4finNonspread</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00133.html">S160</a></td>
-<td>񂐑</td>
-<td></td>
+<td class="signwriting">񂐑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -748,8 +774,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00154.html">S1c3</a></td>
-<td>񄤱</td>
-<td></td>
+<td class="signwriting">񄤱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -757,8 +783,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00271.html">S1e6</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -766,8 +792,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00222.html">S174</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -775,8 +801,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00005.html">S1f9</a></td>
-<td>񅵱</td>
-<td></td>
+<td class="signwriting">񅵱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -784,8 +810,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -793,8 +819,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -802,8 +828,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -811,8 +837,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00226.html">S17a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -820,8 +846,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00116.html">S13f</a></td>
-<td>񁞱</td>
-<td></td>
+<td class="signwriting">񁞱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -829,8 +855,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00061.html">S121</a></td>
-<td>񀱱</td>
-<td></td>
+<td class="signwriting">񀱱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -838,8 +864,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00143.html">S1ba</a></td>
-<td>񄗁</td>
-<td></td>
+<td class="signwriting">񄗁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -847,8 +873,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00158.html">S1d4</a></td>
-<td>񄾑</td>
-<td></td>
+<td class="signwriting">񄾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -856,8 +882,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00277.html">S1fa</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -865,8 +891,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00115.html">S13d</a></td>
-<td>񁛡</td>
-<td>񁛱</td>
+<td class="signwriting">񁛡</td>
+<td class="signwriting">񁛱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -874,8 +900,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00088.html">S170</a></td>
-<td>񂨑</td>
-<td></td>
+<td class="signwriting">񂨑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -883,8 +909,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00106.html">S1e7</a></td>
-<td>񅚱</td>
-<td></td>
+<td class="signwriting">񅚱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -892,8 +918,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -901,8 +927,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00216.html">S167</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -910,8 +936,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00097.html">S145</a></td>
-<td>񁧱</td>
-<td></td>
+<td class="signwriting">񁧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -919,8 +945,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00127.html">S173</a></td>
-<td>񂬱</td>
-<td></td>
+<td class="signwriting">񂬱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -928,8 +954,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00243.html">S1a1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -937,8 +963,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00270.html">S1e3</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -946,8 +972,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00089.html">S171</a></td>
-<td>񂩱</td>
-<td></td>
+<td class="signwriting">񂩱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -955,8 +981,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00155.html">S1d1</a></td>
-<td>񄹱</td>
-<td></td>
+<td class="signwriting">񄹱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -964,8 +990,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00094.html">S146</a></td>
-<td>񁩑</td>
-<td></td>
+<td class="signwriting">񁩑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -973,8 +999,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00264.html">S1c9</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -982,8 +1008,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -991,8 +1017,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00114.html">S129</a></td>
-<td>񀽱</td>
-<td></td>
+<td class="signwriting">񀽱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1000,8 +1026,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00269.html">S1db</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1009,8 +1035,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00188.html">S131</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1018,8 +1044,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00141.html">S1a4</a></td>
-<td>񃶁</td>
-<td></td>
+<td class="signwriting">񃶁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1027,8 +1053,8 @@
 <td>3_nonspread</td>
 <td>extended</td>
 <td><a href="../segments/seg00066.html">S18e</a></td>
-<td>񃕑</td>
-<td></td>
+<td class="signwriting">񃕑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1036,8 +1062,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00121.html">S128</a></td>
-<td>񀼑</td>
-<td></td>
+<td class="signwriting">񀼑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1045,8 +1071,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00191.html">S135</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1054,8 +1080,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00260.html">S1c0</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1063,8 +1089,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00142.html">S1a5</a></td>
-<td>񃷱</td>
-<td></td>
+<td class="signwriting">񃷱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1072,8 +1098,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00062.html">S122</a></td>
-<td>񀳑</td>
-<td></td>
+<td class="signwriting">񀳑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1081,8 +1107,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00225.html">S179</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1090,8 +1116,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00123.html">S12b</a></td>
-<td>񁀱</td>
-<td></td>
+<td class="signwriting">񁀱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1099,8 +1125,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00032.html">S1e2</a></td>
-<td>񅓁</td>
-<td></td>
+<td class="signwriting">񅓁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1108,8 +1134,8 @@
 <td>2finNonspread_othersFist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00118.html">S1a3</a></td>
-<td>񃴱</td>
-<td></td>
+<td class="signwriting">񃴱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1117,8 +1143,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00254.html">S1b8</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1126,8 +1152,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00241.html">S19d</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1135,8 +1161,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00209.html">S15f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1144,8 +1170,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00139.html">S187</a></td>
-<td>񃊱</td>
-<td></td>
+<td class="signwriting">񃊱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1153,8 +1179,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00189.html">S133</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1162,8 +1188,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00122.html">S12a</a></td>
-<td>񀿑</td>
-<td></td>
+<td class="signwriting">񀿑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1171,8 +1197,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00040.html">S132</a></td>
-<td>񁋑</td>
-<td></td>
+<td class="signwriting">񁋑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1180,8 +1206,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00058.html">S112</a></td>
-<td>񀛑</td>
-<td></td>
+<td class="signwriting">񀛑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1189,8 +1215,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00150.html">S18c</a></td>
-<td>񃒑</td>
-<td></td>
+<td class="signwriting">񃒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1198,8 +1224,8 @@
 <td>2finNonspread_othersFist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00120.html">S1b3</a></td>
-<td>񄌱</td>
-<td></td>
+<td class="signwriting">񄌱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1207,8 +1233,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00105.html">S1e5</a></td>
-<td>񅗱</td>
-<td></td>
+<td class="signwriting">񅗱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1216,8 +1242,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00215.html">S166</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1225,8 +1251,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00086.html">S168</a></td>
-<td>񂜑</td>
-<td></td>
+<td class="signwriting">񂜑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1234,8 +1260,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00082.html">S14b</a></td>
-<td>񁰱</td>
-<td></td>
+<td class="signwriting">񁰱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1243,8 +1269,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00217.html">S169</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1252,8 +1278,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00237.html">S194</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1261,8 +1287,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00026.html">S1f2</a></td>
-<td>񅫁</td>
-<td></td>
+<td class="signwriting">񅫁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1270,8 +1296,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00240.html">S19b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1279,8 +1305,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00059.html">S123</a></td>
-<td>񀴱</td>
-<td></td>
+<td class="signwriting">񀴱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1288,8 +1314,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00167.html">S1cd</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1297,8 +1323,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00124.html">S127</a></td>
-<td>񀺱</td>
-<td></td>
+<td class="signwriting">񀺱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1306,8 +1332,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00174.html">S10f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1315,8 +1341,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00238.html">S195</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1324,8 +1350,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00176.html">S113</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1333,8 +1359,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00272.html">S1e8</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1342,8 +1368,8 @@
 <td>4_nonspread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00091.html">S1d7</a></td>
-<td>񅂱</td>
-<td></td>
+<td class="signwriting">񅂱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1351,8 +1377,8 @@
 <td>1fin_othersNonfist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00161.html">S196</a></td>
-<td>񃡑</td>
-<td></td>
+<td class="signwriting">񃡑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1360,8 +1386,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00223.html">S175</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1369,8 +1395,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00190.html">S134</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1378,8 +1404,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00096.html">S159</a></td>
-<td>񂅱</td>
-<td></td>
+<td class="signwriting">񂅱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1387,8 +1413,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00267.html">S1cf</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1396,8 +1422,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00163.html">S14a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1405,8 +1431,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00230.html">S183</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1414,8 +1440,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00023.html">S1df</a></td>
-<td>񅎱</td>
-<td></td>
+<td class="signwriting">񅎱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1423,8 +1449,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00276.html">S1f6</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1432,8 +1458,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00178.html">S117</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1441,8 +1467,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00020.html">S1c6</a></td>
-<td>񄩁</td>
-<td>񄩑</td>
+<td class="signwriting">񄩁</td>
+<td class="signwriting">񄩑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1450,8 +1476,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00017.html">S193</a></td>
-<td>񃜱</td>
-<td></td>
+<td class="signwriting">񃜱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1459,8 +1485,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00171.html">S107</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1468,8 +1494,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00208.html">S15e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1477,8 +1503,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00065.html">S142</a></td>
-<td>񁣑</td>
-<td></td>
+<td class="signwriting">񁣑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1486,8 +1512,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00210.html">S161</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1495,8 +1521,8 @@
 <td>2finNonspread_othersFist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00119.html">S1b2</a></td>
-<td>񄋑</td>
-<td></td>
+<td class="signwriting">񄋑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1504,8 +1530,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00235.html">S18a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1513,8 +1539,8 @@
 <td>3_spread</td>
 <td>extended</td>
 <td><a href="../segments/seg00071.html">S18f</a></td>
-<td>񃖱</td>
-<td></td>
+<td class="signwriting">񃖱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1522,8 +1548,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00038.html">S1b5</a></td>
-<td>񄏱</td>
-<td></td>
+<td class="signwriting">񄏱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1531,8 +1557,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00085.html">S149</a></td>
-<td>񁭱</td>
-<td></td>
+<td class="signwriting">񁭱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1540,8 +1566,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00181.html">S11f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1549,8 +1575,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00151.html">S18d</a></td>
-<td>񃓱</td>
-<td></td>
+<td class="signwriting">񃓱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1558,8 +1584,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00184.html">S12c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1567,8 +1593,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00278.html">S1fe</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1576,8 +1602,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00148.html">S1d6</a></td>
-<td>񅁑</td>
-<td></td>
+<td class="signwriting">񅁑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1585,8 +1611,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00206.html">S15b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1594,8 +1620,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00169.html">S102</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1603,8 +1629,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00183.html">S124</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1612,8 +1638,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00244.html">S1a2</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1621,8 +1647,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00152.html">S1da</a></td>
-<td>񅇑</td>
-<td></td>
+<td class="signwriting">񅇑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1630,8 +1656,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00234.html">S189</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1639,8 +1665,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00027.html">S1f3</a></td>
-<td>񅬱</td>
-<td></td>
+<td class="signwriting">񅬱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1648,8 +1674,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00218.html">S16a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1657,8 +1683,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00102.html">S1a7</a></td>
-<td>񃺱</td>
-<td></td>
+<td class="signwriting">񃺱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1666,8 +1692,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00147.html">S1d5</a></td>
-<td>񄿱</td>
-<td></td>
+<td class="signwriting">񄿱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1675,8 +1701,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00041.html">S13e</a></td>
-<td>񁝑</td>
-<td></td>
+<td class="signwriting">񁝑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1684,8 +1710,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00219.html">S16b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1693,8 +1719,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00245.html">S1a6</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1702,8 +1728,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00239.html">S197</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1711,8 +1737,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00055.html">S1b0</a></td>
-<td>񄈑</td>
-<td></td>
+<td class="signwriting">񄈑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1720,8 +1746,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00063.html">S126</a></td>
-<td>񀹑</td>
-<td></td>
+<td class="signwriting">񀹑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1729,8 +1755,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00014.html">S103</a></td>
-<td>񀄱</td>
-<td></td>
+<td class="signwriting">񀄱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1738,8 +1764,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00179.html">S11b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1747,8 +1773,8 @@
 <td>1fin_othersFist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00109.html">S19f</a></td>
-<td>񃮱</td>
-<td></td>
+<td class="signwriting">񃮱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1756,8 +1782,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00251.html">S1b1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1765,8 +1791,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00214.html">S165</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1774,8 +1800,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00236.html">S191</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1783,8 +1809,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00006.html">S1fb</a></td>
-<td>񅸱</td>
-<td></td>
+<td class="signwriting">񅸱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1792,8 +1818,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00256.html">S1bc</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1801,8 +1827,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00177.html">S114</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1810,8 +1836,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00250.html">S1af</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1819,8 +1845,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00252.html">S1b6</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1828,8 +1854,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00048.html">S11d</a></td>
-<td>񀫡</td>
-<td></td>
+<td class="signwriting">񀫡</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1837,8 +1863,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00173.html">S10d</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1846,8 +1872,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00259.html">S1bf</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1855,8 +1881,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00263.html">S1c8</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1864,8 +1890,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00266.html">S1cc</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1873,8 +1899,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00207.html">S15c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1882,8 +1908,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00246.html">S1a8</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1891,8 +1917,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00186.html">S12f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1900,8 +1926,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00104.html">S199</a></td>
-<td>񃥱</td>
-<td></td>
+<td class="signwriting">񃥱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1909,8 +1935,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00231.html">S184</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1918,8 +1944,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00193.html">S137</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1927,8 +1953,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00196.html">S13a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1936,8 +1962,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00057.html">S1cb</a></td>
-<td>񄰱</td>
-<td></td>
+<td class="signwriting">񄰱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1945,8 +1971,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00257.html">S1bd</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1954,8 +1980,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00185.html">S12e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1963,8 +1989,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00007.html">S1fc</a></td>
-<td>񅺡</td>
-<td>񅺑</td>
+<td class="signwriting">񅺡</td>
+<td class="signwriting">񅺑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1972,8 +1998,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00253.html">S1b7</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00060.html
+++ b/inventories/inv00060.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>LGK (SP_107)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>LGK (SP_107)</h1>
@@ -55,8 +81,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00061.html
+++ b/inventories/inv00061.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>LSL (SP_108)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>LSL (SP_108)</h1>
@@ -55,8 +81,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00062.html
+++ b/inventories/inv00062.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>LSM (MT) (SP_31)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>LSM (MT) (SP_31)</h1>
@@ -55,8 +81,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00108.html">S1ed</a></td>
-<td>񅣡</td>
-<td>񅢑</td>
+<td class="signwriting">񅣡</td>
+<td class="signwriting">񅢑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00158.html">S1d4</a></td>
-<td>񄾑</td>
-<td></td>
+<td class="signwriting">񄾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00229.html">S181</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00220.html">S16c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00043.html">S118</a></td>
-<td>񀤑</td>
-<td></td>
+<td class="signwriting">񀤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00134.html">S153</a></td>
-<td>񁼱</td>
-<td></td>
+<td class="signwriting">񁼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00135.html">S154</a></td>
-<td>񁾑</td>
-<td></td>
+<td class="signwriting">񁾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00232.html">S186</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00116.html">S13f</a></td>
-<td>񁞱</td>
-<td></td>
+<td class="signwriting">񁞱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00026.html">S1f2</a></td>
-<td>񅫁</td>
-<td></td>
+<td class="signwriting">񅫁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00131.html">S17d</a></td>
-<td>񂻱</td>
-<td></td>
+<td class="signwriting">񂻱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00222.html">S174</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00205.html">S156</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00130.html">S17c</a></td>
-<td>񂺑</td>
-<td></td>
+<td class="signwriting">񂺑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00113.html">S1f4</a></td>
-<td>񅮁</td>
-<td>񅮑</td>
+<td class="signwriting">񅮁</td>
+<td class="signwriting">񅮑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00151.html">S18d</a></td>
-<td>񃓱</td>
-<td></td>
+<td class="signwriting">񃓱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00101.html">S157</a></td>
-<td>񂂱</td>
-<td></td>
+<td class="signwriting">񂂱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00098.html">S14e</a></td>
-<td>񁵑</td>
-<td></td>
+<td class="signwriting">񁵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -460,8 +486,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00039.html">S119</a></td>
-<td>񀥱</td>
-<td></td>
+<td class="signwriting">񀥱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -469,8 +495,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00227.html">S17b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -478,8 +504,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00228.html">S17f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -487,8 +513,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00022.html">S1de</a></td>
-<td>񅍑</td>
-<td></td>
+<td class="signwriting">񅍑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -496,8 +522,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00163.html">S14a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -505,8 +531,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00155.html">S1d1</a></td>
-<td>񄹱</td>
-<td></td>
+<td class="signwriting">񄹱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -514,8 +540,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00005.html">S1f9</a></td>
-<td>񅵱</td>
-<td></td>
+<td class="signwriting">񅵱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -523,8 +549,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00159.html">S1d8</a></td>
-<td>񅄑</td>
-<td></td>
+<td class="signwriting">񅄑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -532,8 +558,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -541,8 +567,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00273.html">S1ec</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -550,8 +576,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00122.html">S12a</a></td>
-<td>񀿑</td>
-<td></td>
+<td class="signwriting">񀿑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -559,8 +585,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00003.html">S1f8</a></td>
-<td>񅴑</td>
-<td></td>
+<td class="signwriting">񅴑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -568,8 +594,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00166.html">S17e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -577,8 +603,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00146.html">S1d0</a></td>
-<td>񄸑</td>
-<td></td>
+<td class="signwriting">񄸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -586,8 +612,8 @@
 <td>3_nonspread</td>
 <td>extended</td>
 <td><a href="../segments/seg00066.html">S18e</a></td>
-<td>񃕑</td>
-<td></td>
+<td class="signwriting">񃕑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -595,8 +621,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00111.html">S1ee</a></td>
-<td>񅥑</td>
-<td></td>
+<td class="signwriting">񅥑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -604,8 +630,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00103.html">S1c5</a></td>
-<td>񄧱</td>
-<td></td>
+<td class="signwriting">񄧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -613,8 +639,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00083.html">S180</a></td>
-<td>񃀑</td>
-<td>񃀁</td>
+<td class="signwriting">񃀑</td>
+<td class="signwriting">񃀁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -622,8 +648,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00274.html">S1ef</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -631,8 +657,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00202.html">S14f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -640,8 +666,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -649,8 +675,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00204.html">S152</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -658,8 +684,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00165.html">S16f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -667,8 +693,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00006.html">S1fb</a></td>
-<td>񅸱</td>
-<td></td>
+<td class="signwriting">񅸱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -676,8 +702,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00031.html">S1e1</a></td>
-<td>񅑱</td>
-<td>񅑡</td>
+<td class="signwriting">񅑱</td>
+<td class="signwriting">񅑡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -685,8 +711,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -694,8 +720,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00150.html">S18c</a></td>
-<td>񃒑</td>
-<td></td>
+<td class="signwriting">񃒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -703,8 +729,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00223.html">S175</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -712,8 +738,8 @@
 <td>2finNonspread_othersFist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00118.html">S1a3</a></td>
-<td>񃴱</td>
-<td></td>
+<td class="signwriting">񃴱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -721,8 +747,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00089.html">S171</a></td>
-<td>񂩱</td>
-<td></td>
+<td class="signwriting">񂩱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -730,8 +756,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00114.html">S129</a></td>
-<td>񀽱</td>
-<td></td>
+<td class="signwriting">񀽱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -739,8 +765,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00082.html">S14b</a></td>
-<td>񁰱</td>
-<td></td>
+<td class="signwriting">񁰱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -748,8 +774,8 @@
 <td>4finSpread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00137.html">S155</a></td>
-<td>񁿱</td>
-<td></td>
+<td class="signwriting">񁿱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -757,8 +783,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00014.html">S103</a></td>
-<td>񀄱</td>
-<td></td>
+<td class="signwriting">񀄱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -766,8 +792,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00241.html">S19d</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -775,8 +801,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00147.html">S1d5</a></td>
-<td>񄿱</td>
-<td></td>
+<td class="signwriting">񄿱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -784,8 +810,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00230.html">S183</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -793,8 +819,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00127.html">S173</a></td>
-<td>񂬱</td>
-<td></td>
+<td class="signwriting">񂬱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -802,8 +828,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00121.html">S128</a></td>
-<td>񀼑</td>
-<td></td>
+<td class="signwriting">񀼑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -811,8 +837,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00162.html">S10b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -820,8 +846,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00275.html">S1f1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -829,8 +855,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00164.html">S14d</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -838,8 +864,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00271.html">S1e6</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -847,8 +873,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00115.html">S13d</a></td>
-<td>񁛡</td>
-<td>񁛱</td>
+<td class="signwriting">񁛡</td>
+<td class="signwriting">񁛱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -856,8 +882,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00032.html">S1e2</a></td>
-<td>񅓁</td>
-<td></td>
+<td class="signwriting">񅓁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -865,8 +891,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00152.html">S1da</a></td>
-<td>񅇑</td>
-<td></td>
+<td class="signwriting">񅇑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -874,8 +900,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00181.html">S11f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -883,8 +909,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00210.html">S161</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -892,8 +918,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00272.html">S1e8</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -901,8 +927,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00189.html">S133</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -910,8 +936,8 @@
 <td>4finNonspread</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00133.html">S160</a></td>
-<td>񂐑</td>
-<td></td>
+<td class="signwriting">񂐑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -919,8 +945,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00102.html">S1a7</a></td>
-<td>񃺱</td>
-<td></td>
+<td class="signwriting">񃺱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -928,8 +954,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -937,8 +963,8 @@
 <td>1fin_othersNonfist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00160.html">S105</a></td>
-<td>񀇱</td>
-<td></td>
+<td class="signwriting">񀇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -946,8 +972,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00027.html">S1f3</a></td>
-<td>񅬱</td>
-<td></td>
+<td class="signwriting">񅬱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -955,8 +981,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00219.html">S16b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -964,8 +990,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00054.html">S1a0</a></td>
-<td>񃰑</td>
-<td></td>
+<td class="signwriting">񃰑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -973,8 +999,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00041.html">S13e</a></td>
-<td>񁝑</td>
-<td></td>
+<td class="signwriting">񁝑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -982,8 +1008,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00140.html">S18b</a></td>
-<td>񃐱</td>
-<td></td>
+<td class="signwriting">񃐱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -991,8 +1017,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00179.html">S11b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1000,8 +1026,8 @@
 <td>2finNonspread_othersFist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00120.html">S1b3</a></td>
-<td>񄌱</td>
-<td></td>
+<td class="signwriting">񄌱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1009,8 +1035,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00171.html">S107</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1018,8 +1044,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00276.html">S1f6</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1027,8 +1053,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00017.html">S193</a></td>
-<td>񃜱</td>
-<td></td>
+<td class="signwriting">񃜱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1036,8 +1062,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00139.html">S187</a></td>
-<td>񃊱</td>
-<td></td>
+<td class="signwriting">񃊱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1045,8 +1071,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00157.html">S1d3</a></td>
-<td>񄼱</td>
-<td></td>
+<td class="signwriting">񄼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1054,8 +1080,8 @@
 <td>3_spread</td>
 <td>extended</td>
 <td><a href="../segments/seg00071.html">S18f</a></td>
-<td>񃖱</td>
-<td></td>
+<td class="signwriting">񃖱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1063,8 +1089,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00203.html">S151</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1072,8 +1098,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00169.html">S102</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1081,8 +1107,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00215.html">S166</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1090,8 +1116,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00097.html">S145</a></td>
-<td>񁧱</td>
-<td></td>
+<td class="signwriting">񁧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1099,8 +1125,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00226.html">S17a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1108,8 +1134,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00105.html">S1e5</a></td>
-<td>񅗱</td>
-<td></td>
+<td class="signwriting">񅗱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1117,8 +1143,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00209.html">S15f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1126,8 +1152,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00170.html">S104</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1135,8 +1161,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00062.html">S122</a></td>
-<td>񀳑</td>
-<td></td>
+<td class="signwriting">񀳑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1144,8 +1170,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00269.html">S1db</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1153,8 +1179,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00095.html">S158</a></td>
-<td>񂄑</td>
-<td></td>
+<td class="signwriting">񂄑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1162,8 +1188,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00106.html">S1e7</a></td>
-<td>񅚱</td>
-<td></td>
+<td class="signwriting">񅚱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1171,8 +1197,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00154.html">S1c3</a></td>
-<td>񄤱</td>
-<td></td>
+<td class="signwriting">񄤱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1180,8 +1206,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00143.html">S1ba</a></td>
-<td>񄗁</td>
-<td></td>
+<td class="signwriting">񄗁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1189,8 +1215,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00221.html">S172</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1198,8 +1224,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00277.html">S1fa</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1207,8 +1233,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00225.html">S179</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1216,8 +1242,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00234.html">S189</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00063.html
+++ b/inventories/inv00063.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>MSL (SP_128)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>MSL (SP_128)</h1>
@@ -55,8 +81,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00176.html">S113</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00229.html">S181</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00048.html">S11d</a></td>
-<td>񀫡</td>
-<td></td>
+<td class="signwriting">񀫡</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00103.html">S1c5</a></td>
-<td>񄧱</td>
-<td></td>
+<td class="signwriting">񄧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00134.html">S153</a></td>
-<td>񁼱</td>
-<td></td>
+<td class="signwriting">񁼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00058.html">S112</a></td>
-<td>񀛑</td>
-<td></td>
+<td class="signwriting">񀛑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00206.html">S15b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00179.html">S11b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00053.html">S19c</a></td>
-<td>񃪑</td>
-<td></td>
+<td class="signwriting">񃪑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00199.html">S141</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00043.html">S118</a></td>
-<td>񀤑</td>
-<td></td>
+<td class="signwriting">񀤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00162.html">S10b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00097.html">S145</a></td>
-<td>񁧱</td>
-<td></td>
+<td class="signwriting">񁧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00064.html
+++ b/inventories/inv00064.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>LSM (MX) (SP_65)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>LSM (MX) (SP_65)</h1>
@@ -55,8 +81,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00163.html">S14a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00150.html">S18c</a></td>
-<td>񃒑</td>
-<td></td>
+<td class="signwriting">񃒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00039.html">S119</a></td>
-<td>񀥱</td>
-<td></td>
+<td class="signwriting">񀥱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00159.html">S1d8</a></td>
-<td>񅄑</td>
-<td></td>
+<td class="signwriting">񅄑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00053.html">S19c</a></td>
-<td>񃪑</td>
-<td></td>
+<td class="signwriting">񃪑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00134.html">S153</a></td>
-<td>񁼱</td>
-<td></td>
+<td class="signwriting">񁼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00006.html">S1fb</a></td>
-<td>񅸱</td>
-<td></td>
+<td class="signwriting">񅸱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00103.html">S1c5</a></td>
-<td>񄧱</td>
-<td></td>
+<td class="signwriting">񄧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00158.html">S1d4</a></td>
-<td>񄾑</td>
-<td></td>
+<td class="signwriting">񄾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00054.html">S1a0</a></td>
-<td>񃰑</td>
-<td></td>
+<td class="signwriting">񃰑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00273.html">S1ec</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00268.html">S1d9</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00113.html">S1f4</a></td>
-<td>񅮁</td>
-<td>񅮑</td>
+<td class="signwriting">񅮁</td>
+<td class="signwriting">񅮑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00232.html">S186</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00151.html">S18d</a></td>
-<td>񃓱</td>
-<td></td>
+<td class="signwriting">񃓱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00108.html">S1ed</a></td>
-<td>񅣡</td>
-<td>񅢑</td>
+<td class="signwriting">񅣡</td>
+<td class="signwriting">񅢑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00152.html">S1da</a></td>
-<td>񅇑</td>
-<td></td>
+<td class="signwriting">񅇑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00083.html">S180</a></td>
-<td>񃀑</td>
-<td>񃀁</td>
+<td class="signwriting">񃀑</td>
+<td class="signwriting">񃀁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00022.html">S1de</a></td>
-<td>񅍑</td>
-<td></td>
+<td class="signwriting">񅍑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td>4finNonspread</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00133.html">S160</a></td>
-<td>񂐑</td>
-<td></td>
+<td class="signwriting">񂐑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -460,8 +486,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00065.html">S142</a></td>
-<td>񁣑</td>
-<td></td>
+<td class="signwriting">񁣑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -469,8 +495,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00189.html">S133</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -478,8 +504,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00194.html">S138</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -487,8 +513,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00043.html">S118</a></td>
-<td>񀤑</td>
-<td></td>
+<td class="signwriting">񀤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -496,8 +522,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -505,8 +531,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00102.html">S1a7</a></td>
-<td>񃺱</td>
-<td></td>
+<td class="signwriting">񃺱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -514,8 +540,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00275.html">S1f1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -523,8 +549,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00003.html">S1f8</a></td>
-<td>񅴑</td>
-<td></td>
+<td class="signwriting">񅴑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -532,8 +558,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00220.html">S16c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -541,8 +567,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00098.html">S14e</a></td>
-<td>񁵑</td>
-<td></td>
+<td class="signwriting">񁵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -550,8 +576,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00260.html">S1c0</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -559,8 +585,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00116.html">S13f</a></td>
-<td>񁞱</td>
-<td></td>
+<td class="signwriting">񁞱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -568,8 +594,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00031.html">S1e1</a></td>
-<td>񅑱</td>
-<td>񅑡</td>
+<td class="signwriting">񅑱</td>
+<td class="signwriting">񅑡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -577,8 +603,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00101.html">S157</a></td>
-<td>񂂱</td>
-<td></td>
+<td class="signwriting">񂂱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -586,8 +612,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00131.html">S17d</a></td>
-<td>񂻱</td>
-<td></td>
+<td class="signwriting">񂻱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -595,8 +621,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00062.html">S122</a></td>
-<td>񀳑</td>
-<td></td>
+<td class="signwriting">񀳑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -604,8 +630,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00135.html">S154</a></td>
-<td>񁾑</td>
-<td></td>
+<td class="signwriting">񁾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -613,8 +639,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -622,8 +648,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -631,8 +657,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -640,8 +666,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00058.html">S112</a></td>
-<td>񀛑</td>
-<td></td>
+<td class="signwriting">񀛑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -649,8 +675,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00114.html">S129</a></td>
-<td>񀽱</td>
-<td></td>
+<td class="signwriting">񀽱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -658,8 +684,8 @@
 <td>4finSpread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00137.html">S155</a></td>
-<td>񁿱</td>
-<td></td>
+<td class="signwriting">񁿱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -667,8 +693,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00212.html">S163</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -676,8 +702,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00014.html">S103</a></td>
-<td>񀄱</td>
-<td></td>
+<td class="signwriting">񀄱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -685,8 +711,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00241.html">S19d</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -694,8 +720,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00155.html">S1d1</a></td>
-<td>񄹱</td>
-<td></td>
+<td class="signwriting">񄹱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -703,8 +729,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00229.html">S181</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -712,8 +738,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00271.html">S1e6</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -721,8 +747,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -730,8 +756,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00190.html">S134</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -739,8 +765,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00277.html">S1fa</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -748,8 +774,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00139.html">S187</a></td>
-<td>񃊱</td>
-<td></td>
+<td class="signwriting">񃊱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -757,8 +783,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00172.html">S109</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -766,8 +792,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00207.html">S15c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -775,8 +801,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00204.html">S152</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -784,8 +810,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00019.html">S1ae</a></td>
-<td>񄅑</td>
-<td></td>
+<td class="signwriting">񄅑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -793,8 +819,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00144.html">S1bb</a></td>
-<td>񄘱</td>
-<td></td>
+<td class="signwriting">񄘱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -802,8 +828,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00192.html">S136</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -811,8 +837,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00166.html">S17e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -820,8 +846,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -829,8 +855,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00115.html">S13d</a></td>
-<td>񁛡</td>
-<td>񁛱</td>
+<td class="signwriting">񁛡</td>
+<td class="signwriting">񁛱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -838,8 +864,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00124.html">S127</a></td>
-<td>񀺱</td>
-<td></td>
+<td class="signwriting">񀺱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -847,8 +873,8 @@
 <td>2finNonspread_othersFist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00118.html">S1a3</a></td>
-<td>񃴱</td>
-<td></td>
+<td class="signwriting">񃴱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -856,8 +882,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00228.html">S17f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -865,8 +891,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00211.html">S162</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -874,8 +900,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00162.html">S10b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -883,8 +909,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00215.html">S166</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -892,8 +918,8 @@
 <td>2finNonspread_othersFist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00120.html">S1b3</a></td>
-<td>񄌱</td>
-<td></td>
+<td class="signwriting">񄌱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -901,8 +927,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00154.html">S1c3</a></td>
-<td>񄤱</td>
-<td></td>
+<td class="signwriting">񄤱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -910,8 +936,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00261.html">S1c2</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -919,8 +945,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00030.html">S198</a></td>
-<td>񃤑</td>
-<td></td>
+<td class="signwriting">񃤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -928,8 +954,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00089.html">S171</a></td>
-<td>񂩱</td>
-<td></td>
+<td class="signwriting">񂩱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -937,8 +963,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00005.html">S1f9</a></td>
-<td>񅵱</td>
-<td></td>
+<td class="signwriting">񅵱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -946,8 +972,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00205.html">S156</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -955,8 +981,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00253.html">S1b7</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -964,8 +990,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00244.html">S1a2</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -973,8 +999,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00216.html">S167</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -982,8 +1008,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00146.html">S1d0</a></td>
-<td>񄸑</td>
-<td></td>
+<td class="signwriting">񄸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -991,8 +1017,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00048.html">S11d</a></td>
-<td>񀫡</td>
-<td></td>
+<td class="signwriting">񀫡</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1000,8 +1026,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00140.html">S18b</a></td>
-<td>񃐱</td>
-<td></td>
+<td class="signwriting">񃐱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1009,8 +1035,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00153.html">S1c1</a></td>
-<td>񄡱</td>
-<td></td>
+<td class="signwriting">񄡱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1018,8 +1044,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00224.html">S178</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1027,8 +1053,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00255.html">S1b9</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1036,8 +1062,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00094.html">S146</a></td>
-<td>񁩑</td>
-<td></td>
+<td class="signwriting">񁩑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1045,8 +1071,8 @@
 <td>3_nonspread</td>
 <td>extended</td>
 <td><a href="../segments/seg00066.html">S18e</a></td>
-<td>񃕑</td>
-<td></td>
+<td class="signwriting">񃕑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1054,8 +1080,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00257.html">S1bd</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1063,8 +1089,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00179.html">S11b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1072,8 +1098,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00032.html">S1e2</a></td>
-<td>񅓁</td>
-<td></td>
+<td class="signwriting">񅓁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1081,8 +1107,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00191.html">S135</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1090,8 +1116,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00121.html">S128</a></td>
-<td>񀼑</td>
-<td></td>
+<td class="signwriting">񀼑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1099,8 +1125,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00165.html">S16f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1108,8 +1134,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00167.html">S1cd</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1117,8 +1143,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00097.html">S145</a></td>
-<td>񁧱</td>
-<td></td>
+<td class="signwriting">񁧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1126,8 +1152,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00246.html">S1a8</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1135,8 +1161,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00130.html">S17c</a></td>
-<td>񂺑</td>
-<td></td>
+<td class="signwriting">񂺑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1144,8 +1170,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00174.html">S10f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00065.html
+++ b/inventories/inv00065.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>BIM (SP_66)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>BIM (SP_66)</h1>
@@ -55,8 +81,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00066.html
+++ b/inventories/inv00066.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>NSL (NG) (SP_32)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>NSL (NG) (SP_32)</h1>
@@ -55,8 +81,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00067.html
+++ b/inventories/inv00067.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ISN (SP_67)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>ISN (SP_67)</h1>
@@ -55,8 +81,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00089.html">S171</a></td>
-<td>񂩱</td>
-<td></td>
+<td class="signwriting">񂩱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00101.html">S157</a></td>
-<td>񂂱</td>
-<td></td>
+<td class="signwriting">񂂱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00134.html">S153</a></td>
-<td>񁼱</td>
-<td></td>
+<td class="signwriting">񁼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00165.html">S16f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00108.html">S1ed</a></td>
-<td>񅣡</td>
-<td>񅢑</td>
+<td class="signwriting">񅣡</td>
+<td class="signwriting">񅢑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00131.html">S17d</a></td>
-<td>񂻱</td>
-<td></td>
+<td class="signwriting">񂻱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00274.html">S1ef</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00043.html">S118</a></td>
-<td>񀤑</td>
-<td></td>
+<td class="signwriting">񀤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00273.html">S1ec</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00158.html">S1d4</a></td>
-<td>񄾑</td>
-<td></td>
+<td class="signwriting">񄾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00152.html">S1da</a></td>
-<td>񅇑</td>
-<td></td>
+<td class="signwriting">񅇑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00083.html">S180</a></td>
-<td>񃀑</td>
-<td>񃀁</td>
+<td class="signwriting">񃀑</td>
+<td class="signwriting">񃀁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00113.html">S1f4</a></td>
-<td>񅮁</td>
-<td>񅮑</td>
+<td class="signwriting">񅮁</td>
+<td class="signwriting">񅮑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00114.html">S129</a></td>
-<td>񀽱</td>
-<td></td>
+<td class="signwriting">񀽱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00151.html">S18d</a></td>
-<td>񃓱</td>
-<td></td>
+<td class="signwriting">񃓱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00155.html">S1d1</a></td>
-<td>񄹱</td>
-<td></td>
+<td class="signwriting">񄹱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00139.html">S187</a></td>
-<td>񃊱</td>
-<td></td>
+<td class="signwriting">񃊱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -460,8 +486,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00065.html">S142</a></td>
-<td>񁣑</td>
-<td></td>
+<td class="signwriting">񁣑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -469,8 +495,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00024.html">S1e0</a></td>
-<td>񅐁</td>
-<td>񅐑</td>
+<td class="signwriting">񅐁</td>
+<td class="signwriting">񅐑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -478,8 +504,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00163.html">S14a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -487,8 +513,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -496,8 +522,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00039.html">S119</a></td>
-<td>񀥱</td>
-<td></td>
+<td class="signwriting">񀥱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -505,8 +531,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00156.html">S1d2</a></td>
-<td>񄻑</td>
-<td></td>
+<td class="signwriting">񄻑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -514,8 +540,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00223.html">S175</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -523,8 +549,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -532,8 +558,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00275.html">S1f1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -541,8 +567,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00031.html">S1e1</a></td>
-<td>񅑱</td>
-<td>񅑡</td>
+<td class="signwriting">񅑱</td>
+<td class="signwriting">񅑡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -550,8 +576,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00150.html">S18c</a></td>
-<td>񃒑</td>
-<td></td>
+<td class="signwriting">񃒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -559,8 +585,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00215.html">S166</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -568,8 +594,8 @@
 <td>3_spread</td>
 <td>extended</td>
 <td><a href="../segments/seg00074.html">S1c4</a></td>
-<td>񄦑</td>
-<td></td>
+<td class="signwriting">񄦑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -577,8 +603,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00216.html">S167</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -586,8 +612,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -595,8 +621,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00062.html">S122</a></td>
-<td>񀳑</td>
-<td></td>
+<td class="signwriting">񀳑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -604,8 +630,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00116.html">S13f</a></td>
-<td>񁞱</td>
-<td></td>
+<td class="signwriting">񁞱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -613,8 +639,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00005.html">S1f9</a></td>
-<td>񅵱</td>
-<td></td>
+<td class="signwriting">񅵱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -622,8 +648,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00144.html">S1bb</a></td>
-<td>񄘱</td>
-<td></td>
+<td class="signwriting">񄘱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -631,8 +657,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00098.html">S14e</a></td>
-<td>񁵑</td>
-<td></td>
+<td class="signwriting">񁵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -640,8 +666,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00209.html">S15f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -649,8 +675,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00220.html">S16c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -658,8 +684,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00243.html">S1a1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -667,8 +693,8 @@
 <td>3_nonspread</td>
 <td>extended</td>
 <td><a href="../segments/seg00066.html">S18e</a></td>
-<td>񃕑</td>
-<td></td>
+<td class="signwriting">񃕑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -676,8 +702,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00054.html">S1a0</a></td>
-<td>񃰑</td>
-<td></td>
+<td class="signwriting">񃰑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -685,8 +711,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00121.html">S128</a></td>
-<td>񀼑</td>
-<td></td>
+<td class="signwriting">񀼑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -694,8 +720,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00205.html">S156</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -703,8 +729,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00240.html">S19b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -712,8 +738,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00022.html">S1de</a></td>
-<td>񅍑</td>
-<td></td>
+<td class="signwriting">񅍑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -721,8 +747,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00103.html">S1c5</a></td>
-<td>񄧱</td>
-<td></td>
+<td class="signwriting">񄧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -730,8 +756,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00204.html">S152</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -739,8 +765,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00110.html">S1e4</a></td>
-<td>񅖑</td>
-<td></td>
+<td class="signwriting">񅖑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -748,8 +774,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00115.html">S13d</a></td>
-<td>񁛡</td>
-<td>񁛱</td>
+<td class="signwriting">񁛡</td>
+<td class="signwriting">񁛱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -757,8 +783,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00053.html">S19c</a></td>
-<td>񃪑</td>
-<td></td>
+<td class="signwriting">񃪑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -766,8 +792,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00055.html">S1b0</a></td>
-<td>񄈑</td>
-<td></td>
+<td class="signwriting">񄈑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -775,8 +801,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00267.html">S1cf</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -784,8 +810,8 @@
 <td>4_nonspread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00091.html">S1d7</a></td>
-<td>񅂱</td>
-<td></td>
+<td class="signwriting">񅂱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -793,8 +819,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00142.html">S1a5</a></td>
-<td>񃷱</td>
-<td></td>
+<td class="signwriting">񃷱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -802,8 +828,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00006.html">S1fb</a></td>
-<td>񅸱</td>
-<td></td>
+<td class="signwriting">񅸱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -811,8 +837,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00146.html">S1d0</a></td>
-<td>񄸑</td>
-<td></td>
+<td class="signwriting">񄸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -820,8 +846,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00256.html">S1bc</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -829,8 +855,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00153.html">S1c1</a></td>
-<td>񄡱</td>
-<td></td>
+<td class="signwriting">񄡱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -838,8 +864,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00105.html">S1e5</a></td>
-<td>񅗱</td>
-<td></td>
+<td class="signwriting">񅗱</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00068.html
+++ b/inventories/inv00068.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>NGT, SLN (SP_68)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>NGT, SLN (SP_68)</h1>
@@ -55,8 +81,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00163.html">S14a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00135.html">S154</a></td>
-<td>񁾑</td>
-<td></td>
+<td class="signwriting">񁾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00158.html">S1d4</a></td>
-<td>񄾑</td>
-<td></td>
+<td class="signwriting">񄾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00098.html">S14e</a></td>
-<td>񁵑</td>
-<td></td>
+<td class="signwriting">񁵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00089.html">S171</a></td>
-<td>񂩱</td>
-<td></td>
+<td class="signwriting">񂩱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00151.html">S18d</a></td>
-<td>񃓱</td>
-<td></td>
+<td class="signwriting">񃓱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00039.html">S119</a></td>
-<td>񀥱</td>
-<td></td>
+<td class="signwriting">񀥱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00131.html">S17d</a></td>
-<td>񂻱</td>
-<td></td>
+<td class="signwriting">񂻱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00155.html">S1d1</a></td>
-<td>񄹱</td>
-<td></td>
+<td class="signwriting">񄹱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00232.html">S186</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00103.html">S1c5</a></td>
-<td>񄧱</td>
-<td></td>
+<td class="signwriting">񄧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00204.html">S152</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>3_nonspread</td>
 <td>extended</td>
 <td><a href="../segments/seg00066.html">S18e</a></td>
-<td>񃕑</td>
-<td></td>
+<td class="signwriting">񃕑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00069.html
+++ b/inventories/inv00069.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>NTS, NSL (SP_69)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>NTS, NSL (SP_69)</h1>
@@ -55,8 +81,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00134.html">S153</a></td>
-<td>񁼱</td>
-<td></td>
+<td class="signwriting">񁼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00089.html">S171</a></td>
-<td>񂩱</td>
-<td></td>
+<td class="signwriting">񂩱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00113.html">S1f4</a></td>
-<td>񅮁</td>
-<td>񅮑</td>
+<td class="signwriting">񅮁</td>
+<td class="signwriting">񅮑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00043.html">S118</a></td>
-<td>񀤑</td>
-<td></td>
+<td class="signwriting">񀤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00108.html">S1ed</a></td>
-<td>񅣡</td>
-<td>񅢑</td>
+<td class="signwriting">񅣡</td>
+<td class="signwriting">񅢑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00275.html">S1f1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00131.html">S17d</a></td>
-<td>񂻱</td>
-<td></td>
+<td class="signwriting">񂻱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00274.html">S1ef</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00039.html">S119</a></td>
-<td>񀥱</td>
-<td></td>
+<td class="signwriting">񀥱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00273.html">S1ec</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00135.html">S154</a></td>
-<td>񁾑</td>
-<td></td>
+<td class="signwriting">񁾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00098.html">S14e</a></td>
-<td>񁵑</td>
-<td></td>
+<td class="signwriting">񁵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00163.html">S14a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00232.html">S186</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00220.html">S16c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00103.html">S1c5</a></td>
-<td>񄧱</td>
-<td></td>
+<td class="signwriting">񄧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00229.html">S181</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00158.html">S1d4</a></td>
-<td>񄾑</td>
-<td></td>
+<td class="signwriting">񄾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00111.html">S1ee</a></td>
-<td>񅥑</td>
-<td></td>
+<td class="signwriting">񅥑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00165.html">S16f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -460,8 +486,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -469,8 +495,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -478,8 +504,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00207.html">S15c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -487,8 +513,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00152.html">S1da</a></td>
-<td>񅇑</td>
-<td></td>
+<td class="signwriting">񅇑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -496,8 +522,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00204.html">S152</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -505,8 +531,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -514,8 +540,8 @@
 <td>4finSpread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00137.html">S155</a></td>
-<td>񁿱</td>
-<td></td>
+<td class="signwriting">񁿱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -523,8 +549,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00150.html">S18c</a></td>
-<td>񃒑</td>
-<td></td>
+<td class="signwriting">񃒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -532,8 +558,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00083.html">S180</a></td>
-<td>񃀑</td>
-<td>񃀁</td>
+<td class="signwriting">񃀑</td>
+<td class="signwriting">񃀁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -541,8 +567,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -550,8 +576,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00031.html">S1e1</a></td>
-<td>񅑱</td>
-<td>񅑡</td>
+<td class="signwriting">񅑱</td>
+<td class="signwriting">񅑡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -559,8 +585,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00151.html">S18d</a></td>
-<td>񃓱</td>
-<td></td>
+<td class="signwriting">񃓱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -568,8 +594,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -577,8 +603,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00147.html">S1d5</a></td>
-<td>񄿱</td>
-<td></td>
+<td class="signwriting">񄿱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -586,8 +612,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00139.html">S187</a></td>
-<td>񃊱</td>
-<td></td>
+<td class="signwriting">񃊱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -595,8 +621,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00206.html">S15b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -604,8 +630,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00164.html">S14d</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -613,8 +639,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00130.html">S17c</a></td>
-<td>񂺑</td>
-<td></td>
+<td class="signwriting">񂺑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -622,8 +648,8 @@
 <td>3_nonspread</td>
 <td>extended</td>
 <td><a href="../segments/seg00066.html">S18e</a></td>
-<td>񃕑</td>
-<td></td>
+<td class="signwriting">񃕑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -631,8 +657,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00101.html">S157</a></td>
-<td>񂂱</td>
-<td></td>
+<td class="signwriting">񂂱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -640,8 +666,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00065.html">S142</a></td>
-<td>񁣑</td>
-<td></td>
+<td class="signwriting">񁣑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -649,8 +675,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00121.html">S128</a></td>
-<td>񀼑</td>
-<td></td>
+<td class="signwriting">񀼑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -658,8 +684,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00062.html">S122</a></td>
-<td>񀳑</td>
-<td></td>
+<td class="signwriting">񀳑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -667,8 +693,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00116.html">S13f</a></td>
-<td>񁞱</td>
-<td></td>
+<td class="signwriting">񁞱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -676,8 +702,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00026.html">S1f2</a></td>
-<td>񅫁</td>
-<td></td>
+<td class="signwriting">񅫁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -685,8 +711,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00022.html">S1de</a></td>
-<td>񅍑</td>
-<td></td>
+<td class="signwriting">񅍑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -694,8 +720,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00277.html">S1fa</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -703,8 +729,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00030.html">S198</a></td>
-<td>񃤑</td>
-<td></td>
+<td class="signwriting">񃤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -712,8 +738,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00159.html">S1d8</a></td>
-<td>񅄑</td>
-<td></td>
+<td class="signwriting">񅄑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -721,8 +747,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00156.html">S1d2</a></td>
-<td>񄻑</td>
-<td></td>
+<td class="signwriting">񄻑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -730,8 +756,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00205.html">S156</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -739,8 +765,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00023.html">S1df</a></td>
-<td>񅎱</td>
-<td></td>
+<td class="signwriting">񅎱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -748,8 +774,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00215.html">S166</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -757,8 +783,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00140.html">S18b</a></td>
-<td>񃐱</td>
-<td></td>
+<td class="signwriting">񃐱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -766,8 +792,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00097.html">S145</a></td>
-<td>񁧱</td>
-<td></td>
+<td class="signwriting">񁧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -775,8 +801,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00115.html">S13d</a></td>
-<td>񁛡</td>
-<td>񁛱</td>
+<td class="signwriting">񁛡</td>
+<td class="signwriting">񁛱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -784,8 +810,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00209.html">S15f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -793,8 +819,8 @@
 <td>1fin_othersNonfist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00160.html">S105</a></td>
-<td>񀇱</td>
-<td></td>
+<td class="signwriting">񀇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -802,8 +828,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00216.html">S167</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -811,8 +837,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00054.html">S1a0</a></td>
-<td>񃰑</td>
-<td></td>
+<td class="signwriting">񃰑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -820,8 +846,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00228.html">S17f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -829,8 +855,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00148.html">S1d6</a></td>
-<td>񅁑</td>
-<td></td>
+<td class="signwriting">񅁑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -838,8 +864,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00230.html">S183</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -847,8 +873,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00268.html">S1d9</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -856,8 +882,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00183.html">S124</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -865,8 +891,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00155.html">S1d1</a></td>
-<td>񄹱</td>
-<td></td>
+<td class="signwriting">񄹱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -874,8 +900,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00221.html">S172</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -883,8 +909,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00240.html">S19b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -892,8 +918,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00114.html">S129</a></td>
-<td>񀽱</td>
-<td></td>
+<td class="signwriting">񀽱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -901,8 +927,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00005.html">S1f9</a></td>
-<td>񅵱</td>
-<td></td>
+<td class="signwriting">񅵱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -910,8 +936,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00262.html">S1c7</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -919,8 +945,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00154.html">S1c3</a></td>
-<td>񄤱</td>
-<td></td>
+<td class="signwriting">񄤱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -928,8 +954,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00027.html">S1f3</a></td>
-<td>񅬱</td>
-<td></td>
+<td class="signwriting">񅬱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -937,8 +963,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00006.html">S1fb</a></td>
-<td>񅸱</td>
-<td></td>
+<td class="signwriting">񅸱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -946,8 +972,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00032.html">S1e2</a></td>
-<td>񅓁</td>
-<td></td>
+<td class="signwriting">񅓁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -955,8 +981,8 @@
 <td>1fin_othersNonfist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00161.html">S196</a></td>
-<td>񃡑</td>
-<td></td>
+<td class="signwriting">񃡑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -964,8 +990,8 @@
 <td>1fin_othersFist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00109.html">S19f</a></td>
-<td>񃮱</td>
-<td></td>
+<td class="signwriting">񃮱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -973,8 +999,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00172.html">S109</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -982,8 +1008,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00094.html">S146</a></td>
-<td>񁩑</td>
-<td></td>
+<td class="signwriting">񁩑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -991,8 +1017,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00176.html">S113</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1000,8 +1026,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00053.html">S19c</a></td>
-<td>񃪑</td>
-<td></td>
+<td class="signwriting">񃪑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1009,8 +1035,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00261.html">S1c2</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1018,8 +1044,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00162.html">S10b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1027,8 +1053,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00168.html">S1dd</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1036,8 +1062,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1045,8 +1071,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00276.html">S1f6</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1054,8 +1080,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00003.html">S1f8</a></td>
-<td>񅴑</td>
-<td></td>
+<td class="signwriting">񅴑</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00070.html
+++ b/inventories/inv00070.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>NSL (NP) (SP_133)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>NSL (NP) (SP_133)</h1>
@@ -55,8 +81,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00108.html">S1ed</a></td>
-<td>񅣡</td>
-<td>񅢑</td>
+<td class="signwriting">񅣡</td>
+<td class="signwriting">񅢑</td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00071.html
+++ b/inventories/inv00071.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>NZSL (SP_70)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>NZSL (SP_70)</h1>
@@ -55,8 +81,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00273.html">S1ec</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00030.html">S198</a></td>
-<td>񃤑</td>
-<td></td>
+<td class="signwriting">񃤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00150.html">S18c</a></td>
-<td>񃒑</td>
-<td></td>
+<td class="signwriting">񃒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00072.html
+++ b/inventories/inv00072.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>LSP (SP_71)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>LSP (SP_71)</h1>
@@ -55,8 +81,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00108.html">S1ed</a></td>
-<td>񅣡</td>
-<td>񅢑</td>
+<td class="signwriting">񅣡</td>
+<td class="signwriting">񅢑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>2finNonspread_othersFist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00118.html">S1a3</a></td>
-<td>񃴱</td>
-<td></td>
+<td class="signwriting">񃴱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00151.html">S18d</a></td>
-<td>񃓱</td>
-<td></td>
+<td class="signwriting">񃓱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>4finNonspread</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00133.html">S160</a></td>
-<td>񂐑</td>
-<td></td>
+<td class="signwriting">񂐑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00158.html">S1d4</a></td>
-<td>񄾑</td>
-<td></td>
+<td class="signwriting">񄾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00139.html">S187</a></td>
-<td>񃊱</td>
-<td></td>
+<td class="signwriting">񃊱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00142.html">S1a5</a></td>
-<td>񃷱</td>
-<td></td>
+<td class="signwriting">񃷱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00113.html">S1f4</a></td>
-<td>񅮁</td>
-<td>񅮑</td>
+<td class="signwriting">񅮁</td>
+<td class="signwriting">񅮑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00053.html">S19c</a></td>
-<td>񃪑</td>
-<td></td>
+<td class="signwriting">񃪑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00167.html">S1cd</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00166.html">S17e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00275.html">S1f1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00254.html">S1b8</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00144.html">S1bb</a></td>
-<td>񄘱</td>
-<td></td>
+<td class="signwriting">񄘱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00022.html">S1de</a></td>
-<td>񅍑</td>
-<td></td>
+<td class="signwriting">񅍑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00101.html">S157</a></td>
-<td>񂂱</td>
-<td></td>
+<td class="signwriting">񂂱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00155.html">S1d1</a></td>
-<td>񄹱</td>
-<td></td>
+<td class="signwriting">񄹱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00039.html">S119</a></td>
-<td>񀥱</td>
-<td></td>
+<td class="signwriting">񀥱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00083.html">S180</a></td>
-<td>񃀑</td>
-<td>񃀁</td>
+<td class="signwriting">񃀑</td>
+<td class="signwriting">񃀁</td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00073.html
+++ b/inventories/inv00073.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>FSL (SP_72)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>FSL (SP_72)</h1>
@@ -55,8 +81,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00083.html">S180</a></td>
-<td>񃀑</td>
-<td>񃀁</td>
+<td class="signwriting">񃀑</td>
+<td class="signwriting">񃀁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00103.html">S1c5</a></td>
-<td>񄧱</td>
-<td></td>
+<td class="signwriting">񄧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00139.html">S187</a></td>
-<td>񃊱</td>
-<td></td>
+<td class="signwriting">񃊱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00278.html">S1fe</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00163.html">S14a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00135.html">S154</a></td>
-<td>񁾑</td>
-<td></td>
+<td class="signwriting">񁾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00144.html">S1bb</a></td>
-<td>񄘱</td>
-<td></td>
+<td class="signwriting">񄘱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00165.html">S16f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00220.html">S16c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00022.html">S1de</a></td>
-<td>񅍑</td>
-<td></td>
+<td class="signwriting">񅍑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>4finNonspread</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00133.html">S160</a></td>
-<td>񂐑</td>
-<td></td>
+<td class="signwriting">񂐑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00206.html">S15b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00158.html">S1d4</a></td>
-<td>񄾑</td>
-<td></td>
+<td class="signwriting">񄾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00204.html">S152</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00229.html">S181</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00101.html">S157</a></td>
-<td>񂂱</td>
-<td></td>
+<td class="signwriting">񂂱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00095.html">S158</a></td>
-<td>񂄑</td>
-<td></td>
+<td class="signwriting">񂄑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -460,8 +486,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00039.html">S119</a></td>
-<td>񀥱</td>
-<td></td>
+<td class="signwriting">񀥱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -469,8 +495,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00082.html">S14b</a></td>
-<td>񁰱</td>
-<td></td>
+<td class="signwriting">񁰱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -478,8 +504,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00058.html">S112</a></td>
-<td>񀛑</td>
-<td></td>
+<td class="signwriting">񀛑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -487,8 +513,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00085.html">S149</a></td>
-<td>񁭱</td>
-<td></td>
+<td class="signwriting">񁭱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -496,8 +522,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00216.html">S167</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -505,8 +531,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00243.html">S1a1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -514,8 +540,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00155.html">S1d1</a></td>
-<td>񄹱</td>
-<td></td>
+<td class="signwriting">񄹱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -523,8 +549,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00150.html">S18c</a></td>
-<td>񃒑</td>
-<td></td>
+<td class="signwriting">񃒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -532,8 +558,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00108.html">S1ed</a></td>
-<td>񅣡</td>
-<td>񅢑</td>
+<td class="signwriting">񅣡</td>
+<td class="signwriting">񅢑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -541,8 +567,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00098.html">S14e</a></td>
-<td>񁵑</td>
-<td></td>
+<td class="signwriting">񁵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -550,8 +576,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00116.html">S13f</a></td>
-<td>񁞱</td>
-<td></td>
+<td class="signwriting">񁞱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -559,8 +585,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -568,8 +594,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00232.html">S186</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -577,8 +603,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00277.html">S1fa</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -586,8 +612,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00256.html">S1bc</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -595,8 +621,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00166.html">S17e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -604,8 +630,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00154.html">S1c3</a></td>
-<td>񄤱</td>
-<td></td>
+<td class="signwriting">񄤱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -613,8 +639,8 @@
 <td>4finSpread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00137.html">S155</a></td>
-<td>񁿱</td>
-<td></td>
+<td class="signwriting">񁿱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -622,8 +648,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00131.html">S17d</a></td>
-<td>񂻱</td>
-<td></td>
+<td class="signwriting">񂻱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -631,8 +657,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -640,8 +666,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00274.html">S1ef</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -649,8 +675,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00061.html">S121</a></td>
-<td>񀱱</td>
-<td></td>
+<td class="signwriting">񀱱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -658,8 +684,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00142.html">S1a5</a></td>
-<td>񃷱</td>
-<td></td>
+<td class="signwriting">񃷱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -667,8 +693,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00127.html">S173</a></td>
-<td>񂬱</td>
-<td></td>
+<td class="signwriting">񂬱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -676,8 +702,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00134.html">S153</a></td>
-<td>񁼱</td>
-<td></td>
+<td class="signwriting">񁼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -685,8 +711,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00146.html">S1d0</a></td>
-<td>񄸑</td>
-<td></td>
+<td class="signwriting">񄸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -694,8 +720,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00240.html">S19b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -703,8 +729,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00111.html">S1ee</a></td>
-<td>񅥑</td>
-<td></td>
+<td class="signwriting">񅥑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -712,8 +738,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00054.html">S1a0</a></td>
-<td>񃰑</td>
-<td></td>
+<td class="signwriting">񃰑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -721,8 +747,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00065.html">S142</a></td>
-<td>񁣑</td>
-<td></td>
+<td class="signwriting">񁣑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -730,8 +756,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00215.html">S166</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -739,8 +765,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00043.html">S118</a></td>
-<td>񀤑</td>
-<td></td>
+<td class="signwriting">񀤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -748,8 +774,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00110.html">S1e4</a></td>
-<td>񅖑</td>
-<td></td>
+<td class="signwriting">񅖑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -757,8 +783,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00210.html">S161</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -766,8 +792,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00212.html">S163</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -775,8 +801,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00053.html">S19c</a></td>
-<td>񃪑</td>
-<td></td>
+<td class="signwriting">񃪑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -784,8 +810,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00055.html">S1b0</a></td>
-<td>񄈑</td>
-<td></td>
+<td class="signwriting">񄈑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -793,8 +819,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00275.html">S1f1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -802,8 +828,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00153.html">S1c1</a></td>
-<td>񄡱</td>
-<td></td>
+<td class="signwriting">񄡱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -811,8 +837,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00267.html">S1cf</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00074.html
+++ b/inventories/inv00074.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>PSL (SP_87)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>PSL (SP_87)</h1>
@@ -55,8 +81,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00158.html">S1d4</a></td>
-<td>񄾑</td>
-<td></td>
+<td class="signwriting">񄾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00075.html
+++ b/inventories/inv00075.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>PJM (SP_19)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>PJM (SP_19)</h1>
@@ -55,8 +81,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00083.html">S180</a></td>
-<td>񃀑</td>
-<td>񃀁</td>
+<td class="signwriting">񃀑</td>
+<td class="signwriting">񃀁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00135.html">S154</a></td>
-<td>񁾑</td>
-<td></td>
+<td class="signwriting">񁾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00043.html">S118</a></td>
-<td>񀤑</td>
-<td></td>
+<td class="signwriting">񀤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00103.html">S1c5</a></td>
-<td>񄧱</td>
-<td></td>
+<td class="signwriting">񄧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00158.html">S1d4</a></td>
-<td>񄾑</td>
-<td></td>
+<td class="signwriting">񄾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00223.html">S175</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00273.html">S1ec</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00224.html">S178</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00089.html">S171</a></td>
-<td>񂩱</td>
-<td></td>
+<td class="signwriting">񂩱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00025.html">S10c</a></td>
-<td>񀒑</td>
-<td></td>
+<td class="signwriting">񀒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00098.html">S14e</a></td>
-<td>񁵑</td>
-<td></td>
+<td class="signwriting">񁵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00054.html">S1a0</a></td>
-<td>񃰑</td>
-<td></td>
+<td class="signwriting">񃰑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00220.html">S16c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00275.html">S1f1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00131.html">S17d</a></td>
-<td>񂻱</td>
-<td></td>
+<td class="signwriting">񂻱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00268.html">S1d9</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00211.html">S162</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00062.html">S122</a></td>
-<td>񀳑</td>
-<td></td>
+<td class="signwriting">񀳑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00165.html">S16f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00113.html">S1f4</a></td>
-<td>񅮁</td>
-<td>񅮑</td>
+<td class="signwriting">񅮁</td>
+<td class="signwriting">񅮑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -460,8 +486,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00256.html">S1bc</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -469,8 +495,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00108.html">S1ed</a></td>
-<td>񅣡</td>
-<td>񅢑</td>
+<td class="signwriting">񅣡</td>
+<td class="signwriting">񅢑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -478,8 +504,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00274.html">S1ef</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -487,8 +513,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00229.html">S181</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -496,8 +522,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00139.html">S187</a></td>
-<td>񃊱</td>
-<td></td>
+<td class="signwriting">񃊱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -505,8 +531,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00101.html">S157</a></td>
-<td>񂂱</td>
-<td></td>
+<td class="signwriting">񂂱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -514,8 +540,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00207.html">S15c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -523,8 +549,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00061.html">S121</a></td>
-<td>񀱱</td>
-<td></td>
+<td class="signwriting">񀱱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -532,8 +558,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00166.html">S17e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -541,8 +567,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00039.html">S119</a></td>
-<td>񀥱</td>
-<td></td>
+<td class="signwriting">񀥱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -550,8 +576,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -559,8 +585,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00031.html">S1e1</a></td>
-<td>񅑱</td>
-<td>񅑡</td>
+<td class="signwriting">񅑱</td>
+<td class="signwriting">񅑡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -568,8 +594,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00111.html">S1ee</a></td>
-<td>񅥑</td>
-<td></td>
+<td class="signwriting">񅥑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -577,8 +603,8 @@
 <td>4finSpread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00137.html">S155</a></td>
-<td>񁿱</td>
-<td></td>
+<td class="signwriting">񁿱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -586,8 +612,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -595,8 +621,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00155.html">S1d1</a></td>
-<td>񄹱</td>
-<td></td>
+<td class="signwriting">񄹱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -604,8 +630,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00162.html">S10b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -613,8 +639,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00227.html">S17b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -622,8 +648,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00232.html">S186</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -631,8 +657,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -640,8 +666,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00127.html">S173</a></td>
-<td>񂬱</td>
-<td></td>
+<td class="signwriting">񂬱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -649,8 +675,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00040.html">S132</a></td>
-<td>񁋑</td>
-<td></td>
+<td class="signwriting">񁋑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -658,8 +684,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00159.html">S1d8</a></td>
-<td>񅄑</td>
-<td></td>
+<td class="signwriting">񅄑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -667,8 +693,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00225.html">S179</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -676,8 +702,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00022.html">S1de</a></td>
-<td>񅍑</td>
-<td></td>
+<td class="signwriting">񅍑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -685,8 +711,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00087.html">S16e</a></td>
-<td>񂥑</td>
-<td></td>
+<td class="signwriting">񂥑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -694,8 +720,8 @@
 <td>3_nonspread</td>
 <td>extended</td>
 <td><a href="../segments/seg00066.html">S18e</a></td>
-<td>񃕑</td>
-<td></td>
+<td class="signwriting">񃕑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -703,8 +729,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00134.html">S153</a></td>
-<td>񁼱</td>
-<td></td>
+<td class="signwriting">񁼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -712,8 +738,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00150.html">S18c</a></td>
-<td>񃒑</td>
-<td></td>
+<td class="signwriting">񃒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -721,8 +747,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00228.html">S17f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -730,8 +756,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00114.html">S129</a></td>
-<td>񀽱</td>
-<td></td>
+<td class="signwriting">񀽱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -739,8 +765,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00095.html">S158</a></td>
-<td>񂄑</td>
-<td></td>
+<td class="signwriting">񂄑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -748,8 +774,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00041.html">S13e</a></td>
-<td>񁝑</td>
-<td></td>
+<td class="signwriting">񁝑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -757,8 +783,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00088.html">S170</a></td>
-<td>񂨑</td>
-<td></td>
+<td class="signwriting">񂨑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -766,8 +792,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00167.html">S1cd</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -775,8 +801,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00082.html">S14b</a></td>
-<td>񁰱</td>
-<td></td>
+<td class="signwriting">񁰱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -784,8 +810,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -793,8 +819,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00005.html">S1f9</a></td>
-<td>񅵱</td>
-<td></td>
+<td class="signwriting">񅵱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -802,8 +828,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00116.html">S13f</a></td>
-<td>񁞱</td>
-<td></td>
+<td class="signwriting">񁞱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -811,8 +837,8 @@
 <td>4finNonspread</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00133.html">S160</a></td>
-<td>񂐑</td>
-<td></td>
+<td class="signwriting">񂐑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -820,8 +846,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00183.html">S124</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -829,8 +855,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00157.html">S1d3</a></td>
-<td>񄼱</td>
-<td></td>
+<td class="signwriting">񄼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -838,8 +864,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00151.html">S18d</a></td>
-<td>񃓱</td>
-<td></td>
+<td class="signwriting">񃓱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -847,8 +873,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00221.html">S172</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -856,8 +882,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00076.html
+++ b/inventories/inv00076.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>LGP (SP_33)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>LGP (SP_33)</h1>
@@ -55,8 +81,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00098.html">S14e</a></td>
-<td>񁵑</td>
-<td></td>
+<td class="signwriting">񁵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00108.html">S1ed</a></td>
-<td>񅣡</td>
-<td>񅢑</td>
+<td class="signwriting">񅣡</td>
+<td class="signwriting">񅢑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00113.html">S1f4</a></td>
-<td>񅮁</td>
-<td>񅮑</td>
+<td class="signwriting">񅮁</td>
+<td class="signwriting">񅮑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00083.html">S180</a></td>
-<td>񃀑</td>
-<td>񃀁</td>
+<td class="signwriting">񃀑</td>
+<td class="signwriting">񃀁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00152.html">S1da</a></td>
-<td>񅇑</td>
-<td></td>
+<td class="signwriting">񅇑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00046.html">S116</a></td>
-<td>񀡑</td>
-<td></td>
+<td class="signwriting">񀡑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00116.html">S13f</a></td>
-<td>񁞱</td>
-<td></td>
+<td class="signwriting">񁞱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00103.html">S1c5</a></td>
-<td>񄧱</td>
-<td></td>
+<td class="signwriting">񄧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00209.html">S15f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00232.html">S186</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00162.html">S10b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00123.html">S12b</a></td>
-<td>񁀱</td>
-<td></td>
+<td class="signwriting">񁀱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00003.html">S1f8</a></td>
-<td>񅴑</td>
-<td></td>
+<td class="signwriting">񅴑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00158.html">S1d4</a></td>
-<td>񄾑</td>
-<td></td>
+<td class="signwriting">񄾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00130.html">S17c</a></td>
-<td>񂺑</td>
-<td></td>
+<td class="signwriting">񂺑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00275.html">S1f1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00025.html">S10c</a></td>
-<td>񀒑</td>
-<td></td>
+<td class="signwriting">񀒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00043.html">S118</a></td>
-<td>񀤑</td>
-<td></td>
+<td class="signwriting">񀤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00151.html">S18d</a></td>
-<td>񃓱</td>
-<td></td>
+<td class="signwriting">񃓱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -460,8 +486,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00265.html">S1ca</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -469,8 +495,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00005.html">S1f9</a></td>
-<td>񅵱</td>
-<td></td>
+<td class="signwriting">񅵱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -478,8 +504,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00273.html">S1ec</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -487,8 +513,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00110.html">S1e4</a></td>
-<td>񅖑</td>
-<td></td>
+<td class="signwriting">񅖑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -496,8 +522,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00153.html">S1c1</a></td>
-<td>񄡱</td>
-<td></td>
+<td class="signwriting">񄡱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -505,8 +531,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00147.html">S1d5</a></td>
-<td>񄿱</td>
-<td></td>
+<td class="signwriting">񄿱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -514,8 +540,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00165.html">S16f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -523,8 +549,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00111.html">S1ee</a></td>
-<td>񅥑</td>
-<td></td>
+<td class="signwriting">񅥑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -532,8 +558,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00271.html">S1e6</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -541,8 +567,8 @@
 <td>1fin_othersNonfist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00160.html">S105</a></td>
-<td>񀇱</td>
-<td></td>
+<td class="signwriting">񀇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -550,8 +576,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00146.html">S1d0</a></td>
-<td>񄸑</td>
-<td></td>
+<td class="signwriting">񄸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -559,8 +585,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00101.html">S157</a></td>
-<td>񂂱</td>
-<td></td>
+<td class="signwriting">񂂱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -568,8 +594,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -577,8 +603,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00243.html">S1a1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -586,8 +612,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00228.html">S17f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -595,8 +621,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00148.html">S1d6</a></td>
-<td>񅁑</td>
-<td></td>
+<td class="signwriting">񅁑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -604,8 +630,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00039.html">S119</a></td>
-<td>񀥱</td>
-<td></td>
+<td class="signwriting">񀥱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -613,8 +639,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00150.html">S18c</a></td>
-<td>񃒑</td>
-<td></td>
+<td class="signwriting">񃒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -622,8 +648,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00134.html">S153</a></td>
-<td>񁼱</td>
-<td></td>
+<td class="signwriting">񁼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -631,8 +657,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00159.html">S1d8</a></td>
-<td>񅄑</td>
-<td></td>
+<td class="signwriting">񅄑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -640,8 +666,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00186.html">S12f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -649,8 +675,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00082.html">S14b</a></td>
-<td>񁰱</td>
-<td></td>
+<td class="signwriting">񁰱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -658,8 +684,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00193.html">S137</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -667,8 +693,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00131.html">S17d</a></td>
-<td>񂻱</td>
-<td></td>
+<td class="signwriting">񂻱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -676,8 +702,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -685,8 +711,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00154.html">S1c3</a></td>
-<td>񄤱</td>
-<td></td>
+<td class="signwriting">񄤱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -694,8 +720,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00163.html">S14a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -703,8 +729,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00144.html">S1bb</a></td>
-<td>񄘱</td>
-<td></td>
+<td class="signwriting">񄘱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -712,8 +738,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00274.html">S1ef</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -721,8 +747,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00200.html">S143</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -730,8 +756,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00065.html">S142</a></td>
-<td>񁣑</td>
-<td></td>
+<td class="signwriting">񁣑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -739,8 +765,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00156.html">S1d2</a></td>
-<td>񄻑</td>
-<td></td>
+<td class="signwriting">񄻑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -748,8 +774,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00229.html">S181</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -757,8 +783,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00199.html">S141</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -766,8 +792,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00135.html">S154</a></td>
-<td>񁾑</td>
-<td></td>
+<td class="signwriting">񁾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -775,8 +801,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00269.html">S1db</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -784,8 +810,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00205.html">S156</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -793,8 +819,8 @@
 <td>4finNonspread</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00133.html">S160</a></td>
-<td>񂐑</td>
-<td></td>
+<td class="signwriting">񂐑</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00077.html
+++ b/inventories/inv00077.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>LSPy (SP_129)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>LSPy (SP_129)</h1>
@@ -55,8 +81,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00003.html">S1f8</a></td>
-<td>񅴑</td>
-<td></td>
+<td class="signwriting">񅴑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00025.html">S10c</a></td>
-<td>񀒑</td>
-<td></td>
+<td class="signwriting">񀒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00135.html">S154</a></td>
-<td>񁾑</td>
-<td></td>
+<td class="signwriting">񁾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00134.html">S153</a></td>
-<td>񁼱</td>
-<td></td>
+<td class="signwriting">񁼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00006.html">S1fb</a></td>
-<td>񅸱</td>
-<td></td>
+<td class="signwriting">񅸱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00144.html">S1bb</a></td>
-<td>񄘱</td>
-<td></td>
+<td class="signwriting">񄘱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00043.html">S118</a></td>
-<td>񀤑</td>
-<td></td>
+<td class="signwriting">񀤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00162.html">S10b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00101.html">S157</a></td>
-<td>񂂱</td>
-<td></td>
+<td class="signwriting">񂂱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00039.html">S119</a></td>
-<td>񀥱</td>
-<td></td>
+<td class="signwriting">񀥱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00103.html">S1c5</a></td>
-<td>񄧱</td>
-<td></td>
+<td class="signwriting">񄧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00156.html">S1d2</a></td>
-<td>񄻑</td>
-<td></td>
+<td class="signwriting">񄻑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00108.html">S1ed</a></td>
-<td>񅣡</td>
-<td>񅢑</td>
+<td class="signwriting">񅣡</td>
+<td class="signwriting">񅢑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00083.html">S180</a></td>
-<td>񃀑</td>
-<td>񃀁</td>
+<td class="signwriting">񃀑</td>
+<td class="signwriting">񃀁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00215.html">S166</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00224.html">S178</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00065.html">S142</a></td>
-<td>񁣑</td>
-<td></td>
+<td class="signwriting">񁣑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00229.html">S181</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00164.html">S14d</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -460,8 +486,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00275.html">S1f1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -469,8 +495,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00054.html">S1a0</a></td>
-<td>񃰑</td>
-<td></td>
+<td class="signwriting">񃰑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -478,8 +504,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -487,8 +513,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00131.html">S17d</a></td>
-<td>񂻱</td>
-<td></td>
+<td class="signwriting">񂻱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -496,8 +522,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00189.html">S133</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -505,8 +531,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00222.html">S174</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -514,8 +540,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00111.html">S1ee</a></td>
-<td>񅥑</td>
-<td></td>
+<td class="signwriting">񅥑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -523,8 +549,8 @@
 <td>4finSpread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00137.html">S155</a></td>
-<td>񁿱</td>
-<td></td>
+<td class="signwriting">񁿱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -532,8 +558,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00203.html">S151</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -541,8 +567,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00095.html">S158</a></td>
-<td>񂄑</td>
-<td></td>
+<td class="signwriting">񂄑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -550,8 +576,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00277.html">S1fa</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -559,8 +585,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -568,8 +594,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00158.html">S1d4</a></td>
-<td>񄾑</td>
-<td></td>
+<td class="signwriting">񄾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -577,8 +603,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -586,8 +612,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00085.html">S149</a></td>
-<td>񁭱</td>
-<td></td>
+<td class="signwriting">񁭱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -595,8 +621,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00087.html">S16e</a></td>
-<td>񂥑</td>
-<td></td>
+<td class="signwriting">񂥑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -604,8 +630,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00166.html">S17e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -613,8 +639,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00014.html">S103</a></td>
-<td>񀄱</td>
-<td></td>
+<td class="signwriting">񀄱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -622,8 +648,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00228.html">S17f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -631,8 +657,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00227.html">S17b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -640,8 +666,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00223.html">S175</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -649,8 +675,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00150.html">S18c</a></td>
-<td>񃒑</td>
-<td></td>
+<td class="signwriting">񃒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -658,8 +684,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00272.html">S1e8</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -667,8 +693,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00216.html">S167</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -676,8 +702,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00207.html">S15c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -685,8 +711,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00151.html">S18d</a></td>
-<td>񃓱</td>
-<td></td>
+<td class="signwriting">񃓱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -694,8 +720,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00146.html">S1d0</a></td>
-<td>񄸑</td>
-<td></td>
+<td class="signwriting">񄸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -703,8 +729,8 @@
 <td>4finNonspread</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00133.html">S160</a></td>
-<td>񂐑</td>
-<td></td>
+<td class="signwriting">񂐑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -712,8 +738,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00225.html">S179</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -721,8 +747,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00121.html">S128</a></td>
-<td>񀼑</td>
-<td></td>
+<td class="signwriting">񀼑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -730,8 +756,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00031.html">S1e1</a></td>
-<td>񅑱</td>
-<td>񅑡</td>
+<td class="signwriting">񅑱</td>
+<td class="signwriting">񅑡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -739,8 +765,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00009.html">S1ff</a></td>
-<td>񅾱</td>
-<td></td>
+<td class="signwriting">񅾱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -748,8 +774,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00220.html">S16c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -757,8 +783,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00174.html">S10f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -766,8 +792,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00202.html">S14f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -775,8 +801,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00232.html">S186</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -784,8 +810,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00110.html">S1e4</a></td>
-<td>񅖑</td>
-<td></td>
+<td class="signwriting">񅖑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -793,8 +819,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00124.html">S127</a></td>
-<td>񀺱</td>
-<td></td>
+<td class="signwriting">񀺱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -802,8 +828,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00204.html">S152</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -811,8 +837,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00208.html">S15e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -820,8 +846,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00155.html">S1d1</a></td>
-<td>񄹱</td>
-<td></td>
+<td class="signwriting">񄹱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -829,8 +855,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00273.html">S1ec</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -838,8 +864,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00130.html">S17c</a></td>
-<td>񂺑</td>
-<td></td>
+<td class="signwriting">񂺑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -847,8 +873,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00058.html">S112</a></td>
-<td>񀛑</td>
-<td></td>
+<td class="signwriting">񀛑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -856,8 +882,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00226.html">S17a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -865,8 +891,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00098.html">S14e</a></td>
-<td>񁵑</td>
-<td></td>
+<td class="signwriting">񁵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -874,8 +900,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -883,8 +909,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00102.html">S1a7</a></td>
-<td>񃺱</td>
-<td></td>
+<td class="signwriting">񃺱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -892,8 +918,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00113.html">S1f4</a></td>
-<td>񅮁</td>
-<td>񅮑</td>
+<td class="signwriting">񅮁</td>
+<td class="signwriting">񅮑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -901,8 +927,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00052.html">S125</a></td>
-<td>񀷱</td>
-<td></td>
+<td class="signwriting">񀷱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -910,8 +936,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00022.html">S1de</a></td>
-<td>񅍑</td>
-<td></td>
+<td class="signwriting">񅍑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -919,8 +945,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00185.html">S12e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -928,8 +954,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00152.html">S1da</a></td>
-<td>񅇑</td>
-<td></td>
+<td class="signwriting">񅇑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -937,8 +963,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00274.html">S1ef</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -946,8 +972,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00184.html">S12c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -955,8 +981,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00023.html">S1df</a></td>
-<td>񅎱</td>
-<td></td>
+<td class="signwriting">񅎱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -964,8 +990,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00200.html">S143</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -973,8 +999,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00165.html">S16f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -982,8 +1008,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00154.html">S1c3</a></td>
-<td>񄤱</td>
-<td></td>
+<td class="signwriting">񄤱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -991,8 +1017,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00088.html">S170</a></td>
-<td>񂨑</td>
-<td></td>
+<td class="signwriting">񂨑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1000,8 +1026,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00205.html">S156</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1009,8 +1035,8 @@
 <td>2finNonspread_othersFist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00118.html">S1a3</a></td>
-<td>񃴱</td>
-<td></td>
+<td class="signwriting">񃴱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1018,8 +1044,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00116.html">S13f</a></td>
-<td>񁞱</td>
-<td></td>
+<td class="signwriting">񁞱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1027,8 +1053,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00172.html">S109</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1036,8 +1062,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00062.html">S122</a></td>
-<td>񀳑</td>
-<td></td>
+<td class="signwriting">񀳑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1045,8 +1071,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00157.html">S1d3</a></td>
-<td>񄼱</td>
-<td></td>
+<td class="signwriting">񄼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1054,8 +1080,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00269.html">S1db</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1063,8 +1089,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00105.html">S1e5</a></td>
-<td>񅗱</td>
-<td></td>
+<td class="signwriting">񅗱</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00078.html
+++ b/inventories/inv00078.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>LSR (SP_132)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>LSR (SP_132)</h1>
@@ -55,8 +81,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00227.html">S17b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00098.html">S14e</a></td>
-<td>񁵑</td>
-<td></td>
+<td class="signwriting">񁵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00043.html">S118</a></td>
-<td>񀤑</td>
-<td></td>
+<td class="signwriting">񀤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00115.html">S13d</a></td>
-<td>񁛡</td>
-<td>񁛱</td>
+<td class="signwriting">񁛡</td>
+<td class="signwriting">񁛱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00116.html">S13f</a></td>
-<td>񁞱</td>
-<td></td>
+<td class="signwriting">񁞱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00103.html">S1c5</a></td>
-<td>񄧱</td>
-<td></td>
+<td class="signwriting">񄧱</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00079.html
+++ b/inventories/inv00079.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>RSL (SP_88)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>RSL (SP_88)</h1>
@@ -55,8 +81,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00003.html">S1f8</a></td>
-<td>񅴑</td>
-<td></td>
+<td class="signwriting">񅴑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00054.html">S1a0</a></td>
-<td>񃰑</td>
-<td></td>
+<td class="signwriting">񃰑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00083.html">S180</a></td>
-<td>񃀑</td>
-<td>񃀁</td>
+<td class="signwriting">񃀑</td>
+<td class="signwriting">񃀁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00108.html">S1ed</a></td>
-<td>񅣡</td>
-<td>񅢑</td>
+<td class="signwriting">񅣡</td>
+<td class="signwriting">񅢑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00089.html">S171</a></td>
-<td>񂩱</td>
-<td></td>
+<td class="signwriting">񂩱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00098.html">S14e</a></td>
-<td>񁵑</td>
-<td></td>
+<td class="signwriting">񁵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00144.html">S1bb</a></td>
-<td>񄘱</td>
-<td></td>
+<td class="signwriting">񄘱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00022.html">S1de</a></td>
-<td>񅍑</td>
-<td></td>
+<td class="signwriting">񅍑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00142.html">S1a5</a></td>
-<td>񃷱</td>
-<td></td>
+<td class="signwriting">񃷱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00116.html">S13f</a></td>
-<td>񁞱</td>
-<td></td>
+<td class="signwriting">񁞱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00150.html">S18c</a></td>
-<td>񃒑</td>
-<td></td>
+<td class="signwriting">񃒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00273.html">S1ec</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00101.html">S157</a></td>
-<td>񂂱</td>
-<td></td>
+<td class="signwriting">񂂱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00232.html">S186</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00205.html">S156</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00251.html">S1b1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00135.html">S154</a></td>
-<td>񁾑</td>
-<td></td>
+<td class="signwriting">񁾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00178.html">S117</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00121.html">S128</a></td>
-<td>񀼑</td>
-<td></td>
+<td class="signwriting">񀼑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00154.html">S1c3</a></td>
-<td>񄤱</td>
-<td></td>
+<td class="signwriting">񄤱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00230.html">S183</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -460,8 +486,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00162.html">S10b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -469,8 +495,8 @@
 <td>1fin_othersNonfist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00161.html">S196</a></td>
-<td>񃡑</td>
-<td></td>
+<td class="signwriting">񃡑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -478,8 +504,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -487,8 +513,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -496,8 +522,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -505,8 +531,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00061.html">S121</a></td>
-<td>񀱱</td>
-<td></td>
+<td class="signwriting">񀱱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -514,8 +540,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00103.html">S1c5</a></td>
-<td>񄧱</td>
-<td></td>
+<td class="signwriting">񄧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -523,8 +549,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00218.html">S16a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -532,8 +558,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00202.html">S14f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -541,8 +567,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00165.html">S16f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -550,8 +576,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00031.html">S1e1</a></td>
-<td>񅑱</td>
-<td>񅑡</td>
+<td class="signwriting">񅑱</td>
+<td class="signwriting">񅑡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -559,8 +585,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00080.html
+++ b/inventories/inv00080.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>SSL, SASL (SP_40)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>SSL, SASL (SP_40)</h1>
@@ -55,8 +81,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00273.html">S1ec</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00108.html">S1ed</a></td>
-<td>񅣡</td>
-<td>񅢑</td>
+<td class="signwriting">񅣡</td>
+<td class="signwriting">񅢑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00203.html">S151</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00101.html">S157</a></td>
-<td>񂂱</td>
-<td></td>
+<td class="signwriting">񂂱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00220.html">S16c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00098.html">S14e</a></td>
-<td>񁵑</td>
-<td></td>
+<td class="signwriting">񁵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00114.html">S129</a></td>
-<td>񀽱</td>
-<td></td>
+<td class="signwriting">񀽱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00274.html">S1ef</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00171.html">S107</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00225.html">S179</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00204.html">S152</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00083.html">S180</a></td>
-<td>񃀑</td>
-<td>񃀁</td>
+<td class="signwriting">񃀑</td>
+<td class="signwriting">񃀁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00123.html">S12b</a></td>
-<td>񁀱</td>
-<td></td>
+<td class="signwriting">񁀱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00241.html">S19d</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00207.html">S15c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00089.html">S171</a></td>
-<td>񂩱</td>
-<td></td>
+<td class="signwriting">񂩱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00065.html">S142</a></td>
-<td>񁣑</td>
-<td></td>
+<td class="signwriting">񁣑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00059.html">S123</a></td>
-<td>񀴱</td>
-<td></td>
+<td class="signwriting">񀴱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00224.html">S178</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00130.html">S17c</a></td>
-<td>񂺑</td>
-<td></td>
+<td class="signwriting">񂺑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00177.html">S114</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00039.html">S119</a></td>
-<td>񀥱</td>
-<td></td>
+<td class="signwriting">񀥱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -460,8 +486,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00181.html">S11f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -469,8 +495,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00243.html">S1a1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -478,8 +504,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00135.html">S154</a></td>
-<td>񁾑</td>
-<td></td>
+<td class="signwriting">񁾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -487,8 +513,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00202.html">S14f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -496,8 +522,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00230.html">S183</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -505,8 +531,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00134.html">S153</a></td>
-<td>񁼱</td>
-<td></td>
+<td class="signwriting">񁼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -514,8 +540,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -523,8 +549,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -532,8 +558,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00139.html">S187</a></td>
-<td>񃊱</td>
-<td></td>
+<td class="signwriting">񃊱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -541,8 +567,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -550,8 +576,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00240.html">S19b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -559,8 +585,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00043.html">S118</a></td>
-<td>񀤑</td>
-<td></td>
+<td class="signwriting">񀤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -568,8 +594,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00113.html">S1f4</a></td>
-<td>񅮁</td>
-<td>񅮑</td>
+<td class="signwriting">񅮁</td>
+<td class="signwriting">񅮑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -577,8 +603,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00173.html">S10d</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -586,8 +612,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00116.html">S13f</a></td>
-<td>񁞱</td>
-<td></td>
+<td class="signwriting">񁞱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -595,8 +621,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00229.html">S181</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -604,8 +630,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00223.html">S175</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -613,8 +639,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00131.html">S17d</a></td>
-<td>񂻱</td>
-<td></td>
+<td class="signwriting">񂻱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -622,8 +648,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00277.html">S1fa</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -631,8 +657,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -640,8 +666,8 @@
 <td>1fin_othersNonfist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00160.html">S105</a></td>
-<td>񀇱</td>
-<td></td>
+<td class="signwriting">񀇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -649,8 +675,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00231.html">S184</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -658,8 +684,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00014.html">S103</a></td>
-<td>񀄱</td>
-<td></td>
+<td class="signwriting">񀄱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -667,8 +693,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00158.html">S1d4</a></td>
-<td>񄾑</td>
-<td></td>
+<td class="signwriting">񄾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -676,8 +702,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00166.html">S17e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -685,8 +711,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00048.html">S11d</a></td>
-<td>񀫡</td>
-<td></td>
+<td class="signwriting">񀫡</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -694,8 +720,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -703,8 +729,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00121.html">S128</a></td>
-<td>񀼑</td>
-<td></td>
+<td class="signwriting">񀼑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -712,8 +738,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00027.html">S1f3</a></td>
-<td>񅬱</td>
-<td></td>
+<td class="signwriting">񅬱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -721,8 +747,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00165.html">S16f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -730,8 +756,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00142.html">S1a5</a></td>
-<td>񃷱</td>
-<td></td>
+<td class="signwriting">񃷱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -739,8 +765,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00085.html">S149</a></td>
-<td>񁭱</td>
-<td></td>
+<td class="signwriting">񁭱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -748,8 +774,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00144.html">S1bb</a></td>
-<td>񄘱</td>
-<td></td>
+<td class="signwriting">񄘱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -757,8 +783,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00152.html">S1da</a></td>
-<td>񅇑</td>
-<td></td>
+<td class="signwriting">񅇑</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00081.html
+++ b/inventories/inv00081.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>SSL, STS (SP_73)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>SSL, STS (SP_73)</h1>
@@ -55,8 +81,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00131.html">S17d</a></td>
-<td>񂻱</td>
-<td></td>
+<td class="signwriting">񂻱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00152.html">S1da</a></td>
-<td>񅇑</td>
-<td></td>
+<td class="signwriting">񅇑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00139.html">S187</a></td>
-<td>񃊱</td>
-<td></td>
+<td class="signwriting">񃊱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00022.html">S1de</a></td>
-<td>񅍑</td>
-<td></td>
+<td class="signwriting">񅍑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00020.html">S1c6</a></td>
-<td>񄩁</td>
-<td>񄩑</td>
+<td class="signwriting">񄩁</td>
+<td class="signwriting">񄩑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00083.html">S180</a></td>
-<td>񃀑</td>
-<td>񃀁</td>
+<td class="signwriting">񃀑</td>
+<td class="signwriting">񃀁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00039.html">S119</a></td>
-<td>񀥱</td>
-<td></td>
+<td class="signwriting">񀥱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00151.html">S18d</a></td>
-<td>񃓱</td>
-<td></td>
+<td class="signwriting">񃓱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00159.html">S1d8</a></td>
-<td>񅄑</td>
-<td></td>
+<td class="signwriting">񅄑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00082.html
+++ b/inventories/inv00082.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>SgSL (SP_11)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>SgSL (SP_11)</h1>
@@ -55,8 +81,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00083.html">S180</a></td>
-<td>񃀑</td>
-<td>񃀁</td>
+<td class="signwriting">񃀑</td>
+<td class="signwriting">񃀁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00152.html">S1da</a></td>
-<td>񅇑</td>
-<td></td>
+<td class="signwriting">񅇑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00139.html">S187</a></td>
-<td>񃊱</td>
-<td></td>
+<td class="signwriting">񃊱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00215.html">S166</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00039.html">S119</a></td>
-<td>񀥱</td>
-<td></td>
+<td class="signwriting">񀥱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>4finSpread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00137.html">S155</a></td>
-<td>񁿱</td>
-<td></td>
+<td class="signwriting">񁿱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00144.html">S1bb</a></td>
-<td>񄘱</td>
-<td></td>
+<td class="signwriting">񄘱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00103.html">S1c5</a></td>
-<td>񄧱</td>
-<td></td>
+<td class="signwriting">񄧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00113.html">S1f4</a></td>
-<td>񅮁</td>
-<td>񅮑</td>
+<td class="signwriting">񅮁</td>
+<td class="signwriting">񅮑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00101.html">S157</a></td>
-<td>񂂱</td>
-<td></td>
+<td class="signwriting">񂂱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00232.html">S186</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00274.html">S1ef</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00043.html">S118</a></td>
-<td>񀤑</td>
-<td></td>
+<td class="signwriting">񀤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00108.html">S1ed</a></td>
-<td>񅣡</td>
-<td>񅢑</td>
+<td class="signwriting">񅣡</td>
+<td class="signwriting">񅢑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00206.html">S15b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00164.html">S14d</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00025.html">S10c</a></td>
-<td>񀒑</td>
-<td></td>
+<td class="signwriting">񀒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00220.html">S16c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -460,8 +486,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00158.html">S1d4</a></td>
-<td>񄾑</td>
-<td></td>
+<td class="signwriting">񄾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -469,8 +495,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00135.html">S154</a></td>
-<td>񁾑</td>
-<td></td>
+<td class="signwriting">񁾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -478,8 +504,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00014.html">S103</a></td>
-<td>񀄱</td>
-<td></td>
+<td class="signwriting">񀄱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -487,8 +513,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00151.html">S18d</a></td>
-<td>񃓱</td>
-<td></td>
+<td class="signwriting">񃓱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -496,8 +522,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00205.html">S156</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -505,8 +531,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00130.html">S17c</a></td>
-<td>񂺑</td>
-<td></td>
+<td class="signwriting">񂺑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -514,8 +540,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00131.html">S17d</a></td>
-<td>񂻱</td>
-<td></td>
+<td class="signwriting">񂻱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -523,8 +549,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00110.html">S1e4</a></td>
-<td>񅖑</td>
-<td></td>
+<td class="signwriting">񅖑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -532,8 +558,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -541,8 +567,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00229.html">S181</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -550,8 +576,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00053.html">S19c</a></td>
-<td>񃪑</td>
-<td></td>
+<td class="signwriting">񃪑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -559,8 +585,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -568,8 +594,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00209.html">S15f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -577,8 +603,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00204.html">S152</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -586,8 +612,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00153.html">S1c1</a></td>
-<td>񄡱</td>
-<td></td>
+<td class="signwriting">񄡱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -595,8 +621,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00225.html">S179</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -604,8 +630,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00174.html">S10f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -613,8 +639,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00203.html">S151</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -622,8 +648,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -631,8 +657,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00155.html">S1d1</a></td>
-<td>񄹱</td>
-<td></td>
+<td class="signwriting">񄹱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -640,8 +666,8 @@
 <td>1fin_othersNonfist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00160.html">S105</a></td>
-<td>񀇱</td>
-<td></td>
+<td class="signwriting">񀇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -649,8 +675,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00270.html">S1e3</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -658,8 +684,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00030.html">S198</a></td>
-<td>񃤑</td>
-<td></td>
+<td class="signwriting">񃤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -667,8 +693,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00150.html">S18c</a></td>
-<td>񃒑</td>
-<td></td>
+<td class="signwriting">񃒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -676,8 +702,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00226.html">S17a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -685,8 +711,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00227.html">S17b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -694,8 +720,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00154.html">S1c3</a></td>
-<td>񄤱</td>
-<td></td>
+<td class="signwriting">񄤱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -703,8 +729,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00166.html">S17e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -712,8 +738,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00040.html">S132</a></td>
-<td>񁋑</td>
-<td></td>
+<td class="signwriting">񁋑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -721,8 +747,8 @@
 <td>4finNonspread</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00133.html">S160</a></td>
-<td>񂐑</td>
-<td></td>
+<td class="signwriting">񂐑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -730,8 +756,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00228.html">S17f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -739,8 +765,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00170.html">S104</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -748,8 +774,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00022.html">S1de</a></td>
-<td>񅍑</td>
-<td></td>
+<td class="signwriting">񅍑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -757,8 +783,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -766,8 +792,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00275.html">S1f1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -775,8 +801,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00142.html">S1a5</a></td>
-<td>񃷱</td>
-<td></td>
+<td class="signwriting">񃷱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -784,8 +810,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00003.html">S1f8</a></td>
-<td>񅴑</td>
-<td></td>
+<td class="signwriting">񅴑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -793,8 +819,8 @@
 <td>1fin_othersFist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00109.html">S19f</a></td>
-<td>񃮱</td>
-<td></td>
+<td class="signwriting">񃮱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -802,8 +828,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00207.html">S15c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -811,8 +837,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00115.html">S13d</a></td>
-<td>񁛡</td>
-<td>񁛱</td>
+<td class="signwriting">񁛡</td>
+<td class="signwriting">񁛱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -820,8 +846,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00111.html">S1ee</a></td>
-<td>񅥑</td>
-<td></td>
+<td class="signwriting">񅥑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -829,8 +855,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00116.html">S13f</a></td>
-<td>񁞱</td>
-<td></td>
+<td class="signwriting">񁞱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -838,8 +864,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00031.html">S1e1</a></td>
-<td>񅑱</td>
-<td>񅑡</td>
+<td class="signwriting">񅑱</td>
+<td class="signwriting">񅑡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -847,8 +873,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00146.html">S1d0</a></td>
-<td>񄸑</td>
-<td></td>
+<td class="signwriting">񄸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -856,8 +882,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00260.html">S1c0</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -865,8 +891,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00165.html">S16f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00083.html
+++ b/inventories/inv00083.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>SPJ (SP_89)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>SPJ (SP_89)</h1>
@@ -55,8 +81,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00084.html
+++ b/inventories/inv00084.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>LESSA (SP_137)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>LESSA (SP_137)</h1>
@@ -55,8 +81,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00085.html
+++ b/inventories/inv00085.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>TSL, MSTSL (SP_34)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>TSL, MSTSL (SP_34)</h1>
@@ -55,8 +81,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00113.html">S1f4</a></td>
-<td>񅮁</td>
-<td>񅮑</td>
+<td class="signwriting">񅮁</td>
+<td class="signwriting">񅮑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>4finSpread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00137.html">S155</a></td>
-<td>񁿱</td>
-<td></td>
+<td class="signwriting">񁿱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00135.html">S154</a></td>
-<td>񁾑</td>
-<td></td>
+<td class="signwriting">񁾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00083.html">S180</a></td>
-<td>񃀑</td>
-<td>񃀁</td>
+<td class="signwriting">񃀑</td>
+<td class="signwriting">񃀁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00088.html">S170</a></td>
-<td>񂨑</td>
-<td></td>
+<td class="signwriting">񂨑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00164.html">S14d</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00158.html">S1d4</a></td>
-<td>񄾑</td>
-<td></td>
+<td class="signwriting">񄾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00111.html">S1ee</a></td>
-<td>񅥑</td>
-<td></td>
+<td class="signwriting">񅥑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00006.html">S1fb</a></td>
-<td>񅸱</td>
-<td></td>
+<td class="signwriting">񅸱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00220.html">S16c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00108.html">S1ed</a></td>
-<td>񅣡</td>
-<td>񅢑</td>
+<td class="signwriting">񅣡</td>
+<td class="signwriting">񅢑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00221.html">S172</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00144.html">S1bb</a></td>
-<td>񄘱</td>
-<td></td>
+<td class="signwriting">񄘱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00207.html">S15c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00007.html">S1fc</a></td>
-<td>񅺡</td>
-<td>񅺑</td>
+<td class="signwriting">񅺡</td>
+<td class="signwriting">񅺑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00025.html">S10c</a></td>
-<td>񀒑</td>
-<td></td>
+<td class="signwriting">񀒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00163.html">S14a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00205.html">S156</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00103.html">S1c5</a></td>
-<td>񄧱</td>
-<td></td>
+<td class="signwriting">񄧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00134.html">S153</a></td>
-<td>񁼱</td>
-<td></td>
+<td class="signwriting">񁼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00275.html">S1f1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -460,8 +486,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00139.html">S187</a></td>
-<td>񃊱</td>
-<td></td>
+<td class="signwriting">񃊱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -469,8 +495,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00053.html">S19c</a></td>
-<td>񃪑</td>
-<td></td>
+<td class="signwriting">񃪑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -478,8 +504,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00008.html">S1fd</a></td>
-<td>񅼁</td>
-<td>񅻱</td>
+<td class="signwriting">񅼁</td>
+<td class="signwriting">񅻱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -487,8 +513,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00146.html">S1d0</a></td>
-<td>񄸑</td>
-<td></td>
+<td class="signwriting">񄸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -496,8 +522,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00232.html">S186</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -505,8 +531,8 @@
 <td>3_spread</td>
 <td>extended</td>
 <td><a href="../segments/seg00074.html">S1c4</a></td>
-<td>񄦑</td>
-<td></td>
+<td class="signwriting">񄦑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -514,8 +540,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00276.html">S1f6</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -523,8 +549,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -532,8 +558,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00043.html">S118</a></td>
-<td>񀤑</td>
-<td></td>
+<td class="signwriting">񀤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -541,8 +567,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00142.html">S1a5</a></td>
-<td>񃷱</td>
-<td></td>
+<td class="signwriting">񃷱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -550,8 +576,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00234.html">S189</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -559,8 +585,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00089.html">S171</a></td>
-<td>񂩱</td>
-<td></td>
+<td class="signwriting">񂩱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -568,8 +594,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -577,8 +603,8 @@
 <td>2finNonspread_othersFist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00118.html">S1a3</a></td>
-<td>񃴱</td>
-<td></td>
+<td class="signwriting">񃴱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -586,8 +612,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00162.html">S10b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -595,8 +621,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00110.html">S1e4</a></td>
-<td>񅖑</td>
-<td></td>
+<td class="signwriting">񅖑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -604,8 +630,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00208.html">S15e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -613,8 +639,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00030.html">S198</a></td>
-<td>񃤑</td>
-<td></td>
+<td class="signwriting">񃤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -622,8 +648,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00140.html">S18b</a></td>
-<td>񃐱</td>
-<td></td>
+<td class="signwriting">񃐱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -631,8 +657,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -640,8 +666,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00273.html">S1ec</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -649,8 +675,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00166.html">S17e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -658,8 +684,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00199.html">S141</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -667,8 +693,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00022.html">S1de</a></td>
-<td>񅍑</td>
-<td></td>
+<td class="signwriting">񅍑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -676,8 +702,8 @@
 <td>3_spread</td>
 <td>extended</td>
 <td><a href="../segments/seg00071.html">S18f</a></td>
-<td>񃖱</td>
-<td></td>
+<td class="signwriting">񃖱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -685,8 +711,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00274.html">S1ef</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -694,8 +720,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00147.html">S1d5</a></td>
-<td>񄿱</td>
-<td></td>
+<td class="signwriting">񄿱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -703,8 +729,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -712,8 +738,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00116.html">S13f</a></td>
-<td>񁞱</td>
-<td></td>
+<td class="signwriting">񁞱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -721,8 +747,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00206.html">S15b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -730,8 +756,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00101.html">S157</a></td>
-<td>񂂱</td>
-<td></td>
+<td class="signwriting">񂂱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -739,8 +765,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00203.html">S151</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -748,8 +774,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00031.html">S1e1</a></td>
-<td>񅑱</td>
-<td>񅑡</td>
+<td class="signwriting">񅑱</td>
+<td class="signwriting">񅑡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -757,8 +783,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00130.html">S17c</a></td>
-<td>񂺑</td>
-<td></td>
+<td class="signwriting">񂺑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -766,8 +792,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00003.html">S1f8</a></td>
-<td>񅴑</td>
-<td></td>
+<td class="signwriting">񅴑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -775,8 +801,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00264.html">S1c9</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -784,8 +810,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00269.html">S1db</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -793,8 +819,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00209.html">S15f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -802,8 +828,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00151.html">S18d</a></td>
-<td>񃓱</td>
-<td></td>
+<td class="signwriting">񃓱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -811,8 +837,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00058.html">S112</a></td>
-<td>񀛑</td>
-<td></td>
+<td class="signwriting">񀛑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -820,8 +846,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00065.html">S142</a></td>
-<td>񁣑</td>
-<td></td>
+<td class="signwriting">񁣑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -829,8 +855,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00019.html">S1ae</a></td>
-<td>񄅑</td>
-<td></td>
+<td class="signwriting">񄅑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -838,8 +864,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -847,8 +873,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00095.html">S158</a></td>
-<td>񂄑</td>
-<td></td>
+<td class="signwriting">񂄑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -856,8 +882,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -865,8 +891,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00225.html">S179</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -874,8 +900,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00180.html">S11c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -883,8 +909,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00277.html">S1fa</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -892,8 +918,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00150.html">S18c</a></td>
-<td>񃒑</td>
-<td></td>
+<td class="signwriting">񃒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -901,8 +927,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00086.html
+++ b/inventories/inv00086.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>TunSL (SP_104)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>TunSL (SP_104)</h1>
@@ -55,8 +81,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00158.html">S1d4</a></td>
-<td>񄾑</td>
-<td></td>
+<td class="signwriting">񄾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00083.html">S180</a></td>
-<td>񃀑</td>
-<td>񃀁</td>
+<td class="signwriting">񃀑</td>
+<td class="signwriting">񃀁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00273.html">S1ec</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00103.html">S1c5</a></td>
-<td>񄧱</td>
-<td></td>
+<td class="signwriting">񄧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00204.html">S152</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00108.html">S1ed</a></td>
-<td>񅣡</td>
-<td>񅢑</td>
+<td class="signwriting">񅣡</td>
+<td class="signwriting">񅢑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00039.html">S119</a></td>
-<td>񀥱</td>
-<td></td>
+<td class="signwriting">񀥱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00134.html">S153</a></td>
-<td>񁼱</td>
-<td></td>
+<td class="signwriting">񁼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00043.html">S118</a></td>
-<td>񀤑</td>
-<td></td>
+<td class="signwriting">񀤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00162.html">S10b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00135.html">S154</a></td>
-<td>񁾑</td>
-<td></td>
+<td class="signwriting">񁾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00054.html">S1a0</a></td>
-<td>񃰑</td>
-<td></td>
+<td class="signwriting">񃰑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00229.html">S181</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00163.html">S14a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00113.html">S1f4</a></td>
-<td>񅮁</td>
-<td>񅮑</td>
+<td class="signwriting">񅮁</td>
+<td class="signwriting">񅮑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00121.html">S128</a></td>
-<td>񀼑</td>
-<td></td>
+<td class="signwriting">񀼑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00058.html">S112</a></td>
-<td>񀛑</td>
-<td></td>
+<td class="signwriting">񀛑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -460,8 +486,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00220.html">S16c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -469,8 +495,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00155.html">S1d1</a></td>
-<td>񄹱</td>
-<td></td>
+<td class="signwriting">񄹱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -478,8 +504,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00101.html">S157</a></td>
-<td>񂂱</td>
-<td></td>
+<td class="signwriting">񂂱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -487,8 +513,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00098.html">S14e</a></td>
-<td>񁵑</td>
-<td></td>
+<td class="signwriting">񁵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -496,8 +522,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00166.html">S17e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -505,8 +531,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -514,8 +540,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00131.html">S17d</a></td>
-<td>񂻱</td>
-<td></td>
+<td class="signwriting">񂻱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -523,8 +549,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00097.html">S145</a></td>
-<td>񁧱</td>
-<td></td>
+<td class="signwriting">񁧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -532,8 +558,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00228.html">S17f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -541,8 +567,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00111.html">S1ee</a></td>
-<td>񅥑</td>
-<td></td>
+<td class="signwriting">񅥑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -550,8 +576,8 @@
 <td>4finNonspread</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00133.html">S160</a></td>
-<td>񂐑</td>
-<td></td>
+<td class="signwriting">񂐑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -559,8 +585,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00025.html">S10c</a></td>
-<td>񀒑</td>
-<td></td>
+<td class="signwriting">񀒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -568,8 +594,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00114.html">S129</a></td>
-<td>񀽱</td>
-<td></td>
+<td class="signwriting">񀽱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -577,8 +603,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00144.html">S1bb</a></td>
-<td>񄘱</td>
-<td></td>
+<td class="signwriting">񄘱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -586,8 +612,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00110.html">S1e4</a></td>
-<td>񅖑</td>
-<td></td>
+<td class="signwriting">񅖑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -595,8 +621,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00082.html">S14b</a></td>
-<td>񁰱</td>
-<td></td>
+<td class="signwriting">񁰱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -604,8 +630,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00003.html">S1f8</a></td>
-<td>񅴑</td>
-<td></td>
+<td class="signwriting">񅴑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -613,8 +639,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00224.html">S178</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -622,8 +648,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00124.html">S127</a></td>
-<td>񀺱</td>
-<td></td>
+<td class="signwriting">񀺱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -631,8 +657,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00116.html">S13f</a></td>
-<td>񁞱</td>
-<td></td>
+<td class="signwriting">񁞱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -640,8 +666,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00130.html">S17c</a></td>
-<td>񂺑</td>
-<td></td>
+<td class="signwriting">񂺑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -649,8 +675,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -658,8 +684,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00216.html">S167</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -667,8 +693,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00275.html">S1f1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -676,8 +702,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00062.html">S122</a></td>
-<td>񀳑</td>
-<td></td>
+<td class="signwriting">񀳑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -685,8 +711,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00095.html">S158</a></td>
-<td>񂄑</td>
-<td></td>
+<td class="signwriting">񂄑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -694,8 +720,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00223.html">S175</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -703,8 +729,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00022.html">S1de</a></td>
-<td>񅍑</td>
-<td></td>
+<td class="signwriting">񅍑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -712,8 +738,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00151.html">S18d</a></td>
-<td>񃓱</td>
-<td></td>
+<td class="signwriting">񃓱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -721,8 +747,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00274.html">S1ef</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -730,8 +756,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00156.html">S1d2</a></td>
-<td>񄻑</td>
-<td></td>
+<td class="signwriting">񄻑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -739,8 +765,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00157.html">S1d3</a></td>
-<td>񄼱</td>
-<td></td>
+<td class="signwriting">񄼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -748,8 +774,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00040.html">S132</a></td>
-<td>񁋑</td>
-<td></td>
+<td class="signwriting">񁋑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -757,8 +783,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00165.html">S16f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -766,8 +792,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00059.html">S123</a></td>
-<td>񀴱</td>
-<td></td>
+<td class="signwriting">񀴱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -775,8 +801,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00065.html">S142</a></td>
-<td>񁣑</td>
-<td></td>
+<td class="signwriting">񁣑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -784,8 +810,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00005.html">S1f9</a></td>
-<td>񅵱</td>
-<td></td>
+<td class="signwriting">񅵱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -793,8 +819,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00085.html">S149</a></td>
-<td>񁭱</td>
-<td></td>
+<td class="signwriting">񁭱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -802,8 +828,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00217.html">S169</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -811,8 +837,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -820,8 +846,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00115.html">S13d</a></td>
-<td>񁛡</td>
-<td>񁛱</td>
+<td class="signwriting">񁛡</td>
+<td class="signwriting">񁛱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -829,8 +855,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00146.html">S1d0</a></td>
-<td>񄸑</td>
-<td></td>
+<td class="signwriting">񄸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -838,8 +864,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00087.html">S16e</a></td>
-<td>񂥑</td>
-<td></td>
+<td class="signwriting">񂥑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -847,8 +873,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00256.html">S1bc</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -856,8 +882,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00061.html">S121</a></td>
-<td>񀱱</td>
-<td></td>
+<td class="signwriting">񀱱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -865,8 +891,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00089.html">S171</a></td>
-<td>񂩱</td>
-<td></td>
+<td class="signwriting">񂩱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -874,8 +900,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00031.html">S1e1</a></td>
-<td>񅑱</td>
-<td>񅑡</td>
+<td class="signwriting">񅑱</td>
+<td class="signwriting">񅑡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -883,8 +909,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00194.html">S138</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -892,8 +918,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00267.html">S1cf</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -901,8 +927,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00023.html">S1df</a></td>
-<td>񅎱</td>
-<td></td>
+<td class="signwriting">񅎱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -910,8 +936,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00263.html">S1c8</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -919,8 +945,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00232.html">S186</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -928,8 +954,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00190.html">S134</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -937,8 +963,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00094.html">S146</a></td>
-<td>񁩑</td>
-<td></td>
+<td class="signwriting">񁩑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -946,8 +972,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00006.html">S1fb</a></td>
-<td>񅸱</td>
-<td></td>
+<td class="signwriting">񅸱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -955,8 +981,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00261.html">S1c2</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -964,8 +990,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00270.html">S1e3</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -973,8 +999,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00277.html">S1fa</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -982,8 +1008,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00086.html">S168</a></td>
-<td>񂜑</td>
-<td></td>
+<td class="signwriting">񂜑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -991,8 +1017,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00241.html">S19d</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1000,8 +1026,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00219.html">S16b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1009,8 +1035,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00123.html">S12b</a></td>
-<td>񁀱</td>
-<td></td>
+<td class="signwriting">񁀱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1018,8 +1044,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00154.html">S1c3</a></td>
-<td>񄤱</td>
-<td></td>
+<td class="signwriting">񄤱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1027,8 +1053,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00265.html">S1ca</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1036,8 +1062,8 @@
 <td>2finNonspread_othersFist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00118.html">S1a3</a></td>
-<td>񃴱</td>
-<td></td>
+<td class="signwriting">񃴱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1045,8 +1071,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00153.html">S1c1</a></td>
-<td>񄡱</td>
-<td></td>
+<td class="signwriting">񄡱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1054,8 +1080,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00096.html">S159</a></td>
-<td>񂅱</td>
-<td></td>
+<td class="signwriting">񂅱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1063,8 +1089,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00127.html">S173</a></td>
-<td>񂬱</td>
-<td></td>
+<td class="signwriting">񂬱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1072,8 +1098,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00269.html">S1db</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1081,8 +1107,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00227.html">S17b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1090,8 +1116,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00150.html">S18c</a></td>
-<td>񃒑</td>
-<td></td>
+<td class="signwriting">񃒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1099,8 +1125,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00053.html">S19c</a></td>
-<td>񃪑</td>
-<td></td>
+<td class="signwriting">񃪑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1108,8 +1134,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00246.html">S1a8</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1117,8 +1143,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00024.html">S1e0</a></td>
-<td>񅐁</td>
-<td>񅐑</td>
+<td class="signwriting">񅐁</td>
+<td class="signwriting">񅐑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1126,8 +1152,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00140.html">S18b</a></td>
-<td>񃐱</td>
-<td></td>
+<td class="signwriting">񃐱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1135,8 +1161,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00244.html">S1a2</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1144,8 +1170,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00030.html">S198</a></td>
-<td>񃤑</td>
-<td></td>
+<td class="signwriting">񃤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1153,8 +1179,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00032.html">S1e2</a></td>
-<td>񅓁</td>
-<td></td>
+<td class="signwriting">񅓁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1162,8 +1188,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00185.html">S12e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1171,8 +1197,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00191.html">S135</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1180,8 +1206,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00141.html">S1a4</a></td>
-<td>񃶁</td>
-<td></td>
+<td class="signwriting">񃶁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1189,8 +1215,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00143.html">S1ba</a></td>
-<td>񄗁</td>
-<td></td>
+<td class="signwriting">񄗁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1198,8 +1224,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00048.html">S11d</a></td>
-<td>񀫡</td>
-<td></td>
+<td class="signwriting">񀫡</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1207,8 +1233,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00209.html">S15f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1216,8 +1242,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00147.html">S1d5</a></td>
-<td>񄿱</td>
-<td></td>
+<td class="signwriting">񄿱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1225,8 +1251,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00176.html">S113</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1234,8 +1260,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00171.html">S107</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1243,8 +1269,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00015.html">S108</a></td>
-<td>񀌑</td>
-<td></td>
+<td class="signwriting">񀌑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1252,8 +1278,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00017.html">S193</a></td>
-<td>񃜱</td>
-<td></td>
+<td class="signwriting">񃜱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1261,8 +1287,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00102.html">S1a7</a></td>
-<td>񃺱</td>
-<td></td>
+<td class="signwriting">񃺱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1270,8 +1296,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00245.html">S1a6</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1279,8 +1305,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00167.html">S1cd</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1288,8 +1314,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00142.html">S1a5</a></td>
-<td>񃷱</td>
-<td></td>
+<td class="signwriting">񃷱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1297,8 +1323,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00152.html">S1da</a></td>
-<td>񅇑</td>
-<td></td>
+<td class="signwriting">񅇑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1306,8 +1332,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00260.html">S1c0</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1315,8 +1341,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00225.html">S179</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1324,8 +1350,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00177.html">S114</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1333,8 +1359,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00139.html">S187</a></td>
-<td>񃊱</td>
-<td></td>
+<td class="signwriting">񃊱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1342,8 +1368,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00230.html">S183</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1351,8 +1377,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00026.html">S1f2</a></td>
-<td>񅫁</td>
-<td></td>
+<td class="signwriting">񅫁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1360,8 +1386,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00243.html">S1a1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1369,8 +1395,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00215.html">S166</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1378,8 +1404,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00088.html">S170</a></td>
-<td>񂨑</td>
-<td></td>
+<td class="signwriting">񂨑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1387,8 +1413,8 @@
 <td>4finSpread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00137.html">S155</a></td>
-<td>񁿱</td>
-<td></td>
+<td class="signwriting">񁿱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1396,8 +1422,8 @@
 <td>3_nonspread</td>
 <td>extended</td>
 <td><a href="../segments/seg00066.html">S18e</a></td>
-<td>񃕑</td>
-<td></td>
+<td class="signwriting">񃕑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1405,8 +1431,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00186.html">S12f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1414,8 +1440,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00057.html">S1cb</a></td>
-<td>񄰱</td>
-<td></td>
+<td class="signwriting">񄰱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1423,8 +1449,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00014.html">S103</a></td>
-<td>񀄱</td>
-<td></td>
+<td class="signwriting">񀄱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1432,8 +1458,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00183.html">S124</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1441,8 +1467,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00122.html">S12a</a></td>
-<td>񀿑</td>
-<td></td>
+<td class="signwriting">񀿑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1450,8 +1476,8 @@
 <td>1fin_othersNonfist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00160.html">S105</a></td>
-<td>񀇱</td>
-<td></td>
+<td class="signwriting">񀇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1459,8 +1485,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00268.html">S1d9</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1468,8 +1494,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00206.html">S15b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1477,8 +1503,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00027.html">S1f3</a></td>
-<td>񅬱</td>
-<td></td>
+<td class="signwriting">񅬱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1486,8 +1512,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00148.html">S1d6</a></td>
-<td>񅁑</td>
-<td></td>
+<td class="signwriting">񅁑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1495,8 +1521,8 @@
 <td>4_nonspread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00091.html">S1d7</a></td>
-<td>񅂱</td>
-<td></td>
+<td class="signwriting">񅂱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1504,8 +1530,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00020.html">S1c6</a></td>
-<td>񄩁</td>
-<td>񄩑</td>
+<td class="signwriting">񄩁</td>
+<td class="signwriting">񄩑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1513,8 +1539,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00240.html">S19b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1522,8 +1548,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00203.html">S151</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1531,8 +1557,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00159.html">S1d8</a></td>
-<td>񅄑</td>
-<td></td>
+<td class="signwriting">񅄑</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00087.html
+++ b/inventories/inv00087.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>TİD (SP_90)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>TİD (SP_90)</h1>
@@ -55,8 +81,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00088.html
+++ b/inventories/inv00088.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>TSL (SP_75)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>TSL (SP_75)</h1>
@@ -55,8 +81,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00019.html">S1ae</a></td>
-<td>񄅑</td>
-<td></td>
+<td class="signwriting">񄅑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00134.html">S153</a></td>
-<td>񁼱</td>
-<td></td>
+<td class="signwriting">񁼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00020.html">S1c6</a></td>
-<td>񄩁</td>
-<td>񄩑</td>
+<td class="signwriting">񄩁</td>
+<td class="signwriting">񄩑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00207.html">S15c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00165.html">S16f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00127.html">S173</a></td>
-<td>񂬱</td>
-<td></td>
+<td class="signwriting">񂬱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00022.html">S1de</a></td>
-<td>񅍑</td>
-<td></td>
+<td class="signwriting">񅍑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00152.html">S1da</a></td>
-<td>񅇑</td>
-<td></td>
+<td class="signwriting">񅇑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>2finNonspread_othersFist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00118.html">S1a3</a></td>
-<td>񃴱</td>
-<td></td>
+<td class="signwriting">񃴱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00216.html">S167</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00048.html">S11d</a></td>
-<td>񀫡</td>
-<td></td>
+<td class="signwriting">񀫡</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00166.html">S17e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00273.html">S1ec</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00095.html">S158</a></td>
-<td>񂄑</td>
-<td></td>
+<td class="signwriting">񂄑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00089.html">S171</a></td>
-<td>񂩱</td>
-<td></td>
+<td class="signwriting">񂩱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00146.html">S1d0</a></td>
-<td>񄸑</td>
-<td></td>
+<td class="signwriting">񄸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00101.html">S157</a></td>
-<td>񂂱</td>
-<td></td>
+<td class="signwriting">񂂱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00220.html">S16c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00147.html">S1d5</a></td>
-<td>񄿱</td>
-<td></td>
+<td class="signwriting">񄿱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00219.html">S16b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00088.html">S170</a></td>
-<td>񂨑</td>
-<td></td>
+<td class="signwriting">񂨑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00150.html">S18c</a></td>
-<td>񃒑</td>
-<td></td>
+<td class="signwriting">񃒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -460,8 +486,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00232.html">S186</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -469,8 +495,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00277.html">S1fa</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -478,8 +504,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00162.html">S10b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -487,8 +513,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00243.html">S1a1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -496,8 +522,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00121.html">S128</a></td>
-<td>񀼑</td>
-<td></td>
+<td class="signwriting">񀼑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -505,8 +531,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00139.html">S187</a></td>
-<td>񃊱</td>
-<td></td>
+<td class="signwriting">񃊱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -514,8 +540,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -523,8 +549,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00053.html">S19c</a></td>
-<td>񃪑</td>
-<td></td>
+<td class="signwriting">񃪑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -532,8 +558,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -541,8 +567,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00169.html">S102</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -550,8 +576,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00006.html">S1fb</a></td>
-<td>񅸱</td>
-<td></td>
+<td class="signwriting">񅸱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -559,8 +585,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00115.html">S13d</a></td>
-<td>񁛡</td>
-<td>񁛱</td>
+<td class="signwriting">񁛡</td>
+<td class="signwriting">񁛱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -568,8 +594,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -577,8 +603,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00259.html">S1bf</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -586,8 +612,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00144.html">S1bb</a></td>
-<td>񄘱</td>
-<td></td>
+<td class="signwriting">񄘱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -595,8 +621,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00005.html">S1f9</a></td>
-<td>񅵱</td>
-<td></td>
+<td class="signwriting">񅵱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -604,8 +630,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00205.html">S156</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -613,8 +639,8 @@
 <td>4_nonspread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00091.html">S1d7</a></td>
-<td>񅂱</td>
-<td></td>
+<td class="signwriting">񅂱</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00089.html
+++ b/inventories/inv00089.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>LSU (SP_143)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>LSU (SP_143)</h1>
@@ -55,8 +81,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00003.html">S1f8</a></td>
-<td>񅴑</td>
-<td></td>
+<td class="signwriting">񅴑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>4finSpread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00137.html">S155</a></td>
-<td>񁿱</td>
-<td></td>
+<td class="signwriting">񁿱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00134.html">S153</a></td>
-<td>񁼱</td>
-<td></td>
+<td class="signwriting">񁼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00101.html">S157</a></td>
-<td>񂂱</td>
-<td></td>
+<td class="signwriting">񂂱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00043.html">S118</a></td>
-<td>񀤑</td>
-<td></td>
+<td class="signwriting">񀤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00111.html">S1ee</a></td>
-<td>񅥑</td>
-<td></td>
+<td class="signwriting">񅥑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00108.html">S1ed</a></td>
-<td>񅣡</td>
-<td>񅢑</td>
+<td class="signwriting">񅣡</td>
+<td class="signwriting">񅢑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00216.html">S167</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00267.html">S1cf</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00144.html">S1bb</a></td>
-<td>񄘱</td>
-<td></td>
+<td class="signwriting">񄘱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00204.html">S152</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00054.html">S1a0</a></td>
-<td>񃰑</td>
-<td></td>
+<td class="signwriting">񃰑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00224.html">S178</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00189.html">S133</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00159.html">S1d8</a></td>
-<td>񅄑</td>
-<td></td>
+<td class="signwriting">񅄑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00058.html">S112</a></td>
-<td>񀛑</td>
-<td></td>
+<td class="signwriting">񀛑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00156.html">S1d2</a></td>
-<td>񄻑</td>
-<td></td>
+<td class="signwriting">񄻑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00220.html">S16c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00273.html">S1ec</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00131.html">S17d</a></td>
-<td>񂻱</td>
-<td></td>
+<td class="signwriting">񂻱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td>4finNonspread</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00133.html">S160</a></td>
-<td>񂐑</td>
-<td></td>
+<td class="signwriting">񂐑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00146.html">S1d0</a></td>
-<td>񄸑</td>
-<td></td>
+<td class="signwriting">񄸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -460,8 +486,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -469,8 +495,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -478,8 +504,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00166.html">S17e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -487,8 +513,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00115.html">S13d</a></td>
-<td>񁛡</td>
-<td>񁛱</td>
+<td class="signwriting">񁛡</td>
+<td class="signwriting">񁛱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -496,8 +522,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00113.html">S1f4</a></td>
-<td>񅮁</td>
-<td>񅮑</td>
+<td class="signwriting">񅮁</td>
+<td class="signwriting">񅮑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -505,8 +531,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00155.html">S1d1</a></td>
-<td>񄹱</td>
-<td></td>
+<td class="signwriting">񄹱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -514,8 +540,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00158.html">S1d4</a></td>
-<td>񄾑</td>
-<td></td>
+<td class="signwriting">񄾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -523,8 +549,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -532,8 +558,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -541,8 +567,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00039.html">S119</a></td>
-<td>񀥱</td>
-<td></td>
+<td class="signwriting">񀥱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -550,8 +576,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00193.html">S137</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -559,8 +585,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00194.html">S138</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -568,8 +594,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00163.html">S14a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -577,8 +603,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00157.html">S1d3</a></td>
-<td>񄼱</td>
-<td></td>
+<td class="signwriting">񄼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -586,8 +612,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00246.html">S1a8</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -595,8 +621,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -604,8 +630,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00135.html">S154</a></td>
-<td>񁾑</td>
-<td></td>
+<td class="signwriting">񁾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -613,8 +639,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00150.html">S18c</a></td>
-<td>񃒑</td>
-<td></td>
+<td class="signwriting">񃒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -622,8 +648,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00235.html">S18a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -631,8 +657,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00192.html">S136</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -640,8 +666,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00025.html">S10c</a></td>
-<td>񀒑</td>
-<td></td>
+<td class="signwriting">񀒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -649,8 +675,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00228.html">S17f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -658,8 +684,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -667,8 +693,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00123.html">S12b</a></td>
-<td>񁀱</td>
-<td></td>
+<td class="signwriting">񁀱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -676,8 +702,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00173.html">S10d</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -685,8 +711,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00031.html">S1e1</a></td>
-<td>񅑱</td>
-<td>񅑡</td>
+<td class="signwriting">񅑱</td>
+<td class="signwriting">񅑡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -694,8 +720,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00083.html">S180</a></td>
-<td>񃀑</td>
-<td>񃀁</td>
+<td class="signwriting">񃀑</td>
+<td class="signwriting">񃀁</td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00090.html
+++ b/inventories/inv00090.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>VSL (SP_76)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>VSL (SP_76)</h1>
@@ -55,8 +81,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00158.html">S1d4</a></td>
-<td>񄾑</td>
-<td></td>
+<td class="signwriting">񄾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00103.html">S1c5</a></td>
-<td>񄧱</td>
-<td></td>
+<td class="signwriting">񄧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00220.html">S16c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00144.html">S1bb</a></td>
-<td>񄘱</td>
-<td></td>
+<td class="signwriting">񄘱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00101.html">S157</a></td>
-<td>񂂱</td>
-<td></td>
+<td class="signwriting">񂂱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00098.html">S14e</a></td>
-<td>񁵑</td>
-<td></td>
+<td class="signwriting">񁵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00150.html">S18c</a></td>
-<td>񃒑</td>
-<td></td>
+<td class="signwriting">񃒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00165.html">S16f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00015.html">S108</a></td>
-<td>񀌑</td>
-<td></td>
+<td class="signwriting">񀌑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00154.html">S1c3</a></td>
-<td>񄤱</td>
-<td></td>
+<td class="signwriting">񄤱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00115.html">S13d</a></td>
-<td>񁛡</td>
-<td>񁛱</td>
+<td class="signwriting">񁛡</td>
+<td class="signwriting">񁛱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00274.html">S1ef</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00053.html">S19c</a></td>
-<td>񃪑</td>
-<td></td>
+<td class="signwriting">񃪑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00184.html">S12c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00054.html">S1a0</a></td>
-<td>񃰑</td>
-<td></td>
+<td class="signwriting">񃰑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00152.html">S1da</a></td>
-<td>񅇑</td>
-<td></td>
+<td class="signwriting">񅇑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00234.html">S189</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00166.html">S17e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td>4finNonspread</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00133.html">S160</a></td>
-<td>񂐑</td>
-<td></td>
+<td class="signwriting">񂐑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00215.html">S166</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00232.html">S186</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00091.html
+++ b/inventories/inv00091.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>IS (SP_35)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>IS (SP_35)</h1>
@@ -55,8 +81,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00151.html">S18d</a></td>
-<td>񃓱</td>
-<td></td>
+<td class="signwriting">񃓱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00039.html">S119</a></td>
-<td>񀥱</td>
-<td></td>
+<td class="signwriting">񀥱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00101.html">S157</a></td>
-<td>񂂱</td>
-<td></td>
+<td class="signwriting">񂂱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00232.html">S186</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00163.html">S14a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00134.html">S153</a></td>
-<td>񁼱</td>
-<td></td>
+<td class="signwriting">񁼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00053.html">S19c</a></td>
-<td>񃪑</td>
-<td></td>
+<td class="signwriting">񃪑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00273.html">S1ec</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00116.html">S13f</a></td>
-<td>񁞱</td>
-<td></td>
+<td class="signwriting">񁞱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00139.html">S187</a></td>
-<td>񃊱</td>
-<td></td>
+<td class="signwriting">񃊱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00083.html">S180</a></td>
-<td>񃀑</td>
-<td>񃀁</td>
+<td class="signwriting">񃀑</td>
+<td class="signwriting">񃀁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td>4finNonspread</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00133.html">S160</a></td>
-<td>񂐑</td>
-<td></td>
+<td class="signwriting">񂐑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td>4finSpread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00137.html">S155</a></td>
-<td>񁿱</td>
-<td></td>
+<td class="signwriting">񁿱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00006.html">S1fb</a></td>
-<td>񅸱</td>
-<td></td>
+<td class="signwriting">񅸱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00274.html">S1ef</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00020.html">S1c6</a></td>
-<td>񄩁</td>
-<td>񄩑</td>
+<td class="signwriting">񄩁</td>
+<td class="signwriting">񄩑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00227.html">S17b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00212.html">S163</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00229.html">S181</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00054.html">S1a0</a></td>
-<td>񃰑</td>
-<td></td>
+<td class="signwriting">񃰑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -460,8 +486,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00103.html">S1c5</a></td>
-<td>񄧱</td>
-<td></td>
+<td class="signwriting">񄧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -469,8 +495,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00166.html">S17e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -478,8 +504,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00230.html">S183</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -487,8 +513,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00043.html">S118</a></td>
-<td>񀤑</td>
-<td></td>
+<td class="signwriting">񀤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -496,8 +522,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00026.html">S1f2</a></td>
-<td>񅫁</td>
-<td></td>
+<td class="signwriting">񅫁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -505,8 +531,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00135.html">S154</a></td>
-<td>񁾑</td>
-<td></td>
+<td class="signwriting">񁾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -514,8 +540,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00061.html">S121</a></td>
-<td>񀱱</td>
-<td></td>
+<td class="signwriting">񀱱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -523,8 +549,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00003.html">S1f8</a></td>
-<td>񅴑</td>
-<td></td>
+<td class="signwriting">񅴑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -532,8 +558,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00022.html">S1de</a></td>
-<td>񅍑</td>
-<td></td>
+<td class="signwriting">񅍑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -541,8 +567,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00158.html">S1d4</a></td>
-<td>񄾑</td>
-<td></td>
+<td class="signwriting">񄾑</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00092.html
+++ b/inventories/inv00092.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>SASL (SP_77)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>SASL (SP_77)</h1>
@@ -55,8 +81,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00158.html">S1d4</a></td>
-<td>񄾑</td>
-<td></td>
+<td class="signwriting">񄾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00005.html">S1f9</a></td>
-<td>񅵱</td>
-<td></td>
+<td class="signwriting">񅵱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00164.html">S14d</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00167.html">S1cd</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00025.html">S10c</a></td>
-<td>񀒑</td>
-<td></td>
+<td class="signwriting">񀒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00098.html">S14e</a></td>
-<td>񁵑</td>
-<td></td>
+<td class="signwriting">񁵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00232.html">S186</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00229.html">S181</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>4finNonspread</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00133.html">S160</a></td>
-<td>񂐑</td>
-<td></td>
+<td class="signwriting">񂐑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>3_nonspread</td>
 <td>extended</td>
 <td><a href="../segments/seg00066.html">S18e</a></td>
-<td>񃕑</td>
-<td></td>
+<td class="signwriting">񃕑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00143.html">S1ba</a></td>
-<td>񄗁</td>
-<td></td>
+<td class="signwriting">񄗁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00150.html">S18c</a></td>
-<td>񃒑</td>
-<td></td>
+<td class="signwriting">񃒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00276.html">S1f6</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td>2finNonspread_othersFist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00118.html">S1a3</a></td>
-<td>񃴱</td>
-<td></td>
+<td class="signwriting">񃴱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00156.html">S1d2</a></td>
-<td>񄻑</td>
-<td></td>
+<td class="signwriting">񄻑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00006.html">S1fb</a></td>
-<td>񅸱</td>
-<td></td>
+<td class="signwriting">񅸱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00101.html">S157</a></td>
-<td>񂂱</td>
-<td></td>
+<td class="signwriting">񂂱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -460,8 +486,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00139.html">S187</a></td>
-<td>񃊱</td>
-<td></td>
+<td class="signwriting">񃊱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -469,8 +495,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00141.html">S1a4</a></td>
-<td>񃶁</td>
-<td></td>
+<td class="signwriting">񃶁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -478,8 +504,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00003.html">S1f8</a></td>
-<td>񅴑</td>
-<td></td>
+<td class="signwriting">񅴑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -487,8 +513,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00110.html">S1e4</a></td>
-<td>񅖑</td>
-<td></td>
+<td class="signwriting">񅖑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -496,8 +522,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00113.html">S1f4</a></td>
-<td>񅮁</td>
-<td>񅮑</td>
+<td class="signwriting">񅮁</td>
+<td class="signwriting">񅮑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -505,8 +531,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00154.html">S1c3</a></td>
-<td>񄤱</td>
-<td></td>
+<td class="signwriting">񄤱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -514,8 +540,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00111.html">S1ee</a></td>
-<td>񅥑</td>
-<td></td>
+<td class="signwriting">񅥑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -523,8 +549,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00062.html">S122</a></td>
-<td>񀳑</td>
-<td></td>
+<td class="signwriting">񀳑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -532,8 +558,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00083.html">S180</a></td>
-<td>񃀑</td>
-<td>񃀁</td>
+<td class="signwriting">񃀑</td>
+<td class="signwriting">񃀁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -541,8 +567,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00165.html">S16f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -550,8 +576,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -559,8 +585,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00205.html">S156</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -568,8 +594,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00134.html">S153</a></td>
-<td>񁼱</td>
-<td></td>
+<td class="signwriting">񁼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -577,8 +603,8 @@
 <td>4finSpread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00137.html">S155</a></td>
-<td>񁿱</td>
-<td></td>
+<td class="signwriting">񁿱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -586,8 +612,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00155.html">S1d1</a></td>
-<td>񄹱</td>
-<td></td>
+<td class="signwriting">񄹱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -595,8 +621,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00151.html">S18d</a></td>
-<td>񃓱</td>
-<td></td>
+<td class="signwriting">񃓱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -604,8 +630,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00244.html">S1a2</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -613,8 +639,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00103.html">S1c5</a></td>
-<td>񄧱</td>
-<td></td>
+<td class="signwriting">񄧱</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00093.html
+++ b/inventories/inv00093.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Signuno (SP_54)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Signuno (SP_54)</h1>
@@ -55,8 +81,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00151.html">S18d</a></td>
-<td>񃓱</td>
-<td></td>
+<td class="signwriting">񃓱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00150.html">S18c</a></td>
-<td>񃒑</td>
-<td></td>
+<td class="signwriting">񃒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00039.html">S119</a></td>
-<td>񀥱</td>
-<td></td>
+<td class="signwriting">񀥱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00163.html">S14a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00054.html">S1a0</a></td>
-<td>񃰑</td>
-<td></td>
+<td class="signwriting">񃰑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00135.html">S154</a></td>
-<td>񁾑</td>
-<td></td>
+<td class="signwriting">񁾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00273.html">S1ec</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00152.html">S1da</a></td>
-<td>񅇑</td>
-<td></td>
+<td class="signwriting">񅇑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00139.html">S187</a></td>
-<td>񃊱</td>
-<td></td>
+<td class="signwriting">񃊱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00275.html">S1f1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00055.html">S1b0</a></td>
-<td>񄈑</td>
-<td></td>
+<td class="signwriting">񄈑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00114.html">S129</a></td>
-<td>񀽱</td>
-<td></td>
+<td class="signwriting">񀽱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00103.html">S1c5</a></td>
-<td>񄧱</td>
-<td></td>
+<td class="signwriting">񄧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00142.html">S1a5</a></td>
-<td>񃷱</td>
-<td></td>
+<td class="signwriting">񃷱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00144.html">S1bb</a></td>
-<td>񄘱</td>
-<td></td>
+<td class="signwriting">񄘱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00053.html">S19c</a></td>
-<td>񃪑</td>
-<td></td>
+<td class="signwriting">񃪑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00212.html">S163</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td>3_nonspread</td>
 <td>extended</td>
 <td><a href="../segments/seg00066.html">S18e</a></td>
-<td>񃕑</td>
-<td></td>
+<td class="signwriting">񃕑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00154.html">S1c3</a></td>
-<td>񄤱</td>
-<td></td>
+<td class="signwriting">񄤱</td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/inventories/inv00094.html
+++ b/inventories/inv00094.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>YSL (SP_74)</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>YSL (SP_74)</h1>
@@ -55,8 +81,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -64,8 +90,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -73,8 +99,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -82,8 +108,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -91,8 +117,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -100,8 +126,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00108.html">S1ed</a></td>
-<td>񅣡</td>
-<td>񅢑</td>
+<td class="signwriting">񅣡</td>
+<td class="signwriting">񅢑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -109,8 +135,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -118,8 +144,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="../segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -127,8 +153,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00158.html">S1d4</a></td>
-<td>񄾑</td>
-<td></td>
+<td class="signwriting">񄾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -136,8 +162,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -145,8 +171,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -154,8 +180,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -163,8 +189,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -172,8 +198,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -181,8 +207,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00229.html">S181</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -190,8 +216,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -199,8 +225,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -208,8 +234,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -217,8 +243,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00083.html">S180</a></td>
-<td>񃀑</td>
-<td>񃀁</td>
+<td class="signwriting">񃀑</td>
+<td class="signwriting">񃀁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -226,8 +252,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00103.html">S1c5</a></td>
-<td>񄧱</td>
-<td></td>
+<td class="signwriting">񄧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -235,8 +261,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00113.html">S1f4</a></td>
-<td>񅮁</td>
-<td>񅮑</td>
+<td class="signwriting">񅮁</td>
+<td class="signwriting">񅮑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -244,8 +270,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00134.html">S153</a></td>
-<td>񁼱</td>
-<td></td>
+<td class="signwriting">񁼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -253,8 +279,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -262,8 +288,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -271,8 +297,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00043.html">S118</a></td>
-<td>񀤑</td>
-<td></td>
+<td class="signwriting">񀤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -280,8 +306,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00025.html">S10c</a></td>
-<td>񀒑</td>
-<td></td>
+<td class="signwriting">񀒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -289,8 +315,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00273.html">S1ec</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -298,8 +324,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00098.html">S14e</a></td>
-<td>񁵑</td>
-<td></td>
+<td class="signwriting">񁵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -307,8 +333,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -316,8 +342,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00022.html">S1de</a></td>
-<td>񅍑</td>
-<td></td>
+<td class="signwriting">񅍑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -325,8 +351,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00135.html">S154</a></td>
-<td>񁾑</td>
-<td></td>
+<td class="signwriting">񁾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -334,8 +360,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -343,8 +369,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00003.html">S1f8</a></td>
-<td>񅴑</td>
-<td></td>
+<td class="signwriting">񅴑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -352,8 +378,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00116.html">S13f</a></td>
-<td>񁞱</td>
-<td></td>
+<td class="signwriting">񁞱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -361,8 +387,8 @@
 <td>4finNonspread</td>
 <td>(fingers straight)</td>
 <td><a href="../segments/seg00133.html">S160</a></td>
-<td>񂐑</td>
-<td></td>
+<td class="signwriting">񂐑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -370,8 +396,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00162.html">S10b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -379,8 +405,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00131.html">S17d</a></td>
-<td>񂻱</td>
-<td></td>
+<td class="signwriting">񂻱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -388,8 +414,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -397,8 +423,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00230.html">S183</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -406,8 +432,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -415,8 +441,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -424,8 +450,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -433,8 +459,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00224.html">S178</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -442,8 +468,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -451,8 +477,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00031.html">S1e1</a></td>
-<td>񅑱</td>
-<td>񅑡</td>
+<td class="signwriting">񅑱</td>
+<td class="signwriting">񅑡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -460,8 +486,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00111.html">S1ee</a></td>
-<td>񅥑</td>
-<td></td>
+<td class="signwriting">񅥑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -469,8 +495,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00164.html">S14d</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -478,8 +504,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00220.html">S16c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -487,8 +513,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00039.html">S119</a></td>
-<td>񀥱</td>
-<td></td>
+<td class="signwriting">񀥱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -496,8 +522,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00222.html">S174</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -505,8 +531,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="../segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -514,8 +540,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -523,8 +549,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00146.html">S1d0</a></td>
-<td>񄸑</td>
-<td></td>
+<td class="signwriting">񄸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -532,8 +558,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -541,8 +567,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="../segments/seg00155.html">S1d1</a></td>
-<td>񄹱</td>
-<td></td>
+<td class="signwriting">񄹱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -550,8 +576,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00274.html">S1ef</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -559,8 +585,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -568,8 +594,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00032.html">S1e2</a></td>
-<td>񅓁</td>
-<td></td>
+<td class="signwriting">񅓁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -577,8 +603,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00144.html">S1bb</a></td>
-<td>񄘱</td>
-<td></td>
+<td class="signwriting">񄘱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -586,8 +612,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00127.html">S173</a></td>
-<td>񂬱</td>
-<td></td>
+<td class="signwriting">񂬱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -595,8 +621,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00275.html">S1f1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -604,8 +630,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00228.html">S17f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -613,8 +639,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00151.html">S18d</a></td>
-<td>񃓱</td>
-<td></td>
+<td class="signwriting">񃓱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -622,8 +648,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00202.html">S14f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -631,8 +657,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00082.html">S14b</a></td>
-<td>񁰱</td>
-<td></td>
+<td class="signwriting">񁰱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -640,8 +666,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="../segments/seg00101.html">S157</a></td>
-<td>񂂱</td>
-<td></td>
+<td class="signwriting">񂂱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -649,8 +675,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00276.html">S1f6</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -658,8 +684,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00163.html">S14a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -667,8 +693,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00165.html">S16f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -676,8 +702,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -685,8 +711,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00256.html">S1bc</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -694,8 +720,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -703,8 +729,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00014.html">S103</a></td>
-<td>񀄱</td>
-<td></td>
+<td class="signwriting">񀄱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -712,8 +738,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00166.html">S17e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -721,8 +747,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -730,8 +756,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00227.html">S17b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -739,8 +765,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00204.html">S152</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -748,8 +774,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00152.html">S1da</a></td>
-<td>񅇑</td>
-<td></td>
+<td class="signwriting">񅇑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -757,8 +783,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00058.html">S112</a></td>
-<td>񀛑</td>
-<td></td>
+<td class="signwriting">񀛑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -766,8 +792,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="../segments/seg00147.html">S1d5</a></td>
-<td>񄿱</td>
-<td></td>
+<td class="signwriting">񄿱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -775,8 +801,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00223.html">S175</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -784,8 +810,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00232.html">S186</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -793,8 +819,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00114.html">S129</a></td>
-<td>񀽱</td>
-<td></td>
+<td class="signwriting">񀽱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -802,8 +828,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00205.html">S156</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -811,8 +837,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00167.html">S1cd</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -820,8 +846,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00115.html">S13d</a></td>
-<td>񁛡</td>
-<td>񁛱</td>
+<td class="signwriting">񁛡</td>
+<td class="signwriting">񁛱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -829,8 +855,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00206.html">S15b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -838,8 +864,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="../segments/seg00006.html">S1fb</a></td>
-<td>񅸱</td>
-<td></td>
+<td class="signwriting">񅸱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -847,8 +873,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="../segments/seg00150.html">S18c</a></td>
-<td>񃒑</td>
-<td></td>
+<td class="signwriting">񃒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -856,8 +882,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00023.html">S1df</a></td>
-<td>񅎱</td>
-<td></td>
+<td class="signwriting">񅎱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -865,8 +891,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00203.html">S151</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -874,8 +900,8 @@
 <td>2finNonspread_othersFist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="../segments/seg00118.html">S1a3</a></td>
-<td>񃴱</td>
-<td></td>
+<td class="signwriting">񃴱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -883,8 +909,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00057.html">S1cb</a></td>
-<td>񄰱</td>
-<td></td>
+<td class="signwriting">񄰱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -892,8 +918,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00053.html">S19c</a></td>
-<td>񃪑</td>
-<td></td>
+<td class="signwriting">񃪑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -901,8 +927,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00005.html">S1f9</a></td>
-<td>񅵱</td>
-<td></td>
+<td class="signwriting">񅵱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -910,8 +936,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00180.html">S11c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -919,8 +945,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00130.html">S17c</a></td>
-<td>񂺑</td>
-<td></td>
+<td class="signwriting">񂺑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -928,8 +954,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="../segments/seg00095.html">S158</a></td>
-<td>񂄑</td>
-<td></td>
+<td class="signwriting">񂄑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -937,8 +963,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00271.html">S1e6</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -946,8 +972,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00121.html">S128</a></td>
-<td>񀼑</td>
-<td></td>
+<td class="signwriting">񀼑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -955,8 +981,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="../segments/seg00106.html">S1e7</a></td>
-<td>񅚱</td>
-<td></td>
+<td class="signwriting">񅚱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -964,8 +990,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="../segments/seg00123.html">S12b</a></td>
-<td>񁀱</td>
-<td></td>
+<td class="signwriting">񁀱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -973,8 +999,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00172.html">S109</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -982,8 +1008,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00225.html">S179</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -991,8 +1017,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00175.html">S111</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1000,8 +1026,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="../segments/seg00054.html">S1a0</a></td>
-<td>񃰑</td>
-<td></td>
+<td class="signwriting">񃰑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1009,8 +1035,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00177.html">S114</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1018,8 +1044,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00176.html">S113</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1027,8 +1053,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00097.html">S145</a></td>
-<td>񁧱</td>
-<td></td>
+<td class="signwriting">񁧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1036,8 +1062,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="../segments/seg00062.html">S122</a></td>
-<td>񀳑</td>
-<td></td>
+<td class="signwriting">񀳑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1045,8 +1071,8 @@
 <td></td>
 <td></td>
 <td><a href="../segments/seg00267.html">S1cf</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/scripts/pages/generator.py
+++ b/scripts/pages/generator.py
@@ -2,6 +2,33 @@ import csv
 import html
 from pathlib import Path
 
+SIGNWRITING_FONT_CSS = """
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+"""
+
 
 def load_csv(csv_path):
     with open(csv_path, newline="", encoding="utf-8") as f:
@@ -60,7 +87,11 @@ def render_table(rows, columns_to_show, id_column=None, clickable_column=None, t
                 cell = build_link(value, row[id_column], target_folder)
             else:
                 cell = html.escape(value)
-            parts.append(f"<td>{cell}</td>")
+
+            if col.startswith("signwriting"):
+                parts.append(f'<td class="signwriting">{cell}</td>')
+            else:
+                parts.append(f"<td>{cell}</td>")
         parts.append("</tr>")
 
     parts.append("</tbody></table>")
@@ -74,6 +105,7 @@ def write_page(output_path, title, table_html):
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{html.escape(title)}</title>
+  {SIGNWRITING_FONT_CSS}
 </head>
 <body>
   <h1>{html.escape(title)}</h1>

--- a/scripts/pages/ibuilder.py
+++ b/scripts/pages/ibuilder.py
@@ -5,6 +5,32 @@ import sys
 
 csv.field_size_limit(sys.maxsize)
 
+SIGNWRITING_FONT_CSS = """
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+"""
 
 def load_csv(csv_path):
     with open(csv_path, newline="", encoding="utf-8") as f:
@@ -103,7 +129,11 @@ def render_table(rows, columns_to_show, fsw_column):
                 cell = build_fsw_link(value, row.get("segment_id", ""))
             else:
                 cell = html.escape(value)
-            parts.append(f"<td>{cell}</td>")
+
+            if col.startswith("signwriting"):
+                parts.append(f'<td class="signwriting">{cell}</td>')
+            else:
+                parts.append(f"<td>{cell}</td>")
         parts.append("</tr>")
 
     parts.append("</tbody></table>")
@@ -142,6 +172,7 @@ def write_inventory_page(output_path, title, metadata_html, table_html):
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{html.escape(title)}</title>
+  {SIGNWRITING_FONT_CSS}
 </head>
 <body>
   <h1>{html.escape(title)}</h1>

--- a/scripts/pages/sbuilder.py
+++ b/scripts/pages/sbuilder.py
@@ -4,6 +4,33 @@ from pathlib import Path
 
 csv.field_size_limit(sys.maxsize)
 
+SIGNWRITING_FONT_CSS = """
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+"""
+
 
 def load_csv(csv_path):
     with open(csv_path, newline="", encoding="utf-8") as f:
@@ -101,9 +128,16 @@ def render_segment_details(segment_row, columns_to_show):
     parts.append("<tbody>")
 
     for col in columns_to_show:
+        value = html_escape(segment_row.get(col, ""))
+
         parts.append("<tr>")
         parts.append(f"<th>{html_escape(format_header(col))}</th>")
-        parts.append(f"<td>{html_escape(segment_row.get(col, ''))}</td>")
+
+        if col.startswith("signwriting"):
+            parts.append(f'<td class="signwriting">{value}</td>')
+        else:
+            parts.append(f"<td>{value}</td>")
+
         parts.append("</tr>")
 
     parts.append("</tbody></table>")
@@ -154,6 +188,7 @@ def write_segment_page(output_path, title, details_html, inventory_table_html):
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{html_escape(title)}</title>
+  {SIGNWRITING_FONT_CSS}
 </head>
 <body>
   <h1>{html_escape(title)}</h1>

--- a/segments.html
+++ b/segments.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Segments</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Segments</h1>
@@ -24,8 +50,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="segments/seg00001.html">S1f5</a></td>
-<td>񅯣</td>
-<td>񅯡</td>
+<td class="signwriting">񅯣</td>
+<td class="signwriting">񅯡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -33,8 +59,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="segments/seg00002.html">S1f7</a></td>
-<td>񅲱</td>
-<td>񅳁</td>
+<td class="signwriting">񅲱</td>
+<td class="signwriting">񅳁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -42,8 +68,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="segments/seg00003.html">S1f8</a></td>
-<td>񅴑</td>
-<td></td>
+<td class="signwriting">񅴑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -51,8 +77,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="segments/seg00004.html">S203</a></td>
-<td>񆄱</td>
-<td>񆅁</td>
+<td class="signwriting">񆄱</td>
+<td class="signwriting">񆅁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -60,8 +86,8 @@
 <td>0_finger(Fist)</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="segments/seg00005.html">S1f9</a></td>
-<td>񅵱</td>
-<td></td>
+<td class="signwriting">񅵱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -69,8 +95,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="segments/seg00006.html">S1fb</a></td>
-<td>񅸱</td>
-<td></td>
+<td class="signwriting">񅸱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -78,8 +104,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="segments/seg00007.html">S1fc</a></td>
-<td>񅺡</td>
-<td>񅺑</td>
+<td class="signwriting">񅺡</td>
+<td class="signwriting">񅺑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -87,8 +113,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="segments/seg00008.html">S1fd</a></td>
-<td>񅼁</td>
-<td>񅻱</td>
+<td class="signwriting">񅼁</td>
+<td class="signwriting">񅻱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -96,8 +122,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="segments/seg00009.html">S1ff</a></td>
-<td>񅾱</td>
-<td></td>
+<td class="signwriting">񅾱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -105,8 +131,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="segments/seg00010.html">S200</a></td>
-<td>񆀑</td>
-<td></td>
+<td class="signwriting">񆀑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -114,8 +140,8 @@
 <td>0_finger(Fist)</td>
 <td>(fistDerivation)</td>
 <td><a href="segments/seg00011.html">S201</a></td>
-<td>񆁱</td>
-<td></td>
+<td class="signwriting">񆁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -123,8 +149,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="segments/seg00012.html">S100</a></td>
-<td>񀀁</td>
-<td></td>
+<td class="signwriting">񀀁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -132,8 +158,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="segments/seg00013.html">S101</a></td>
-<td>񀁱</td>
-<td></td>
+<td class="signwriting">񀁱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -141,8 +167,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="segments/seg00014.html">S103</a></td>
-<td>񀄱</td>
-<td></td>
+<td class="signwriting">񀄱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -150,8 +176,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="segments/seg00015.html">S108</a></td>
-<td>񀌑</td>
-<td></td>
+<td class="signwriting">񀌑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -159,8 +185,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="segments/seg00016.html">S192</a></td>
-<td>񃛑</td>
-<td>񃛁</td>
+<td class="signwriting">񃛑</td>
+<td class="signwriting">񃛁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -168,8 +194,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="segments/seg00017.html">S193</a></td>
-<td>񃜱</td>
-<td></td>
+<td class="signwriting">񃜱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -177,8 +203,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="segments/seg00018.html">S19a</a></td>
-<td>񃧑</td>
-<td>񃧁</td>
+<td class="signwriting">񃧑</td>
+<td class="signwriting">񃧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -186,8 +212,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="segments/seg00019.html">S1ae</a></td>
-<td>񄅑</td>
-<td></td>
+<td class="signwriting">񄅑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -195,8 +221,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="segments/seg00020.html">S1c6</a></td>
-<td>񄩁</td>
-<td>񄩑</td>
+<td class="signwriting">񄩁</td>
+<td class="signwriting">񄩑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -204,8 +230,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="segments/seg00021.html">S1dc</a></td>
-<td>񅊑</td>
-<td>񅊡</td>
+<td class="signwriting">񅊑</td>
+<td class="signwriting">񅊡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -213,8 +239,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="segments/seg00022.html">S1de</a></td>
-<td>񅍑</td>
-<td></td>
+<td class="signwriting">񅍑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -222,8 +248,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="segments/seg00023.html">S1df</a></td>
-<td>񅎱</td>
-<td></td>
+<td class="signwriting">񅎱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -231,8 +257,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="segments/seg00024.html">S1e0</a></td>
-<td>񅐁</td>
-<td>񅐑</td>
+<td class="signwriting">񅐁</td>
+<td class="signwriting">񅐑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -240,8 +266,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="segments/seg00025.html">S10c</a></td>
-<td>񀒑</td>
-<td></td>
+<td class="signwriting">񀒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -249,8 +275,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="segments/seg00026.html">S1f2</a></td>
-<td>񅫁</td>
-<td></td>
+<td class="signwriting">񅫁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -258,8 +284,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="segments/seg00027.html">S1f3</a></td>
-<td>񅬱</td>
-<td></td>
+<td class="signwriting">񅬱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -267,8 +293,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="segments/seg00028.html">S106</a></td>
-<td>񀉑</td>
-<td></td>
+<td class="signwriting">񀉑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -276,8 +302,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="segments/seg00029.html">S10a</a></td>
-<td>񀏑</td>
-<td></td>
+<td class="signwriting">񀏑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -285,8 +311,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="segments/seg00030.html">S198</a></td>
-<td>񃤑</td>
-<td></td>
+<td class="signwriting">񃤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -294,8 +320,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="segments/seg00031.html">S1e1</a></td>
-<td>񅑱</td>
-<td>񅑡</td>
+<td class="signwriting">񅑱</td>
+<td class="signwriting">񅑡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -303,8 +329,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="segments/seg00032.html">S1e2</a></td>
-<td>񅓁</td>
-<td></td>
+<td class="signwriting">񅓁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -312,8 +338,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="segments/seg00033.html">Missing</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -321,8 +347,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="segments/seg00034.html">Missing</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -330,8 +356,8 @@
 <td>1_finger</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="segments/seg00035.html">S1ea</a></td>
-<td>񅟑</td>
-<td>񅟁</td>
+<td class="signwriting">񅟑</td>
+<td class="signwriting">񅟁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -339,8 +365,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="segments/seg00036.html">S115</a></td>
-<td>񀟱</td>
-<td></td>
+<td class="signwriting">񀟱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -348,8 +374,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="segments/seg00037.html">S12d</a></td>
-<td>񁃡</td>
-<td>񁃱</td>
+<td class="signwriting">񁃡</td>
+<td class="signwriting">񁃱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -357,8 +383,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="segments/seg00038.html">S1b5</a></td>
-<td>񄏱</td>
-<td></td>
+<td class="signwriting">񄏱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -366,8 +392,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="segments/seg00039.html">S119</a></td>
-<td>񀥱</td>
-<td></td>
+<td class="signwriting">񀥱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -375,8 +401,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="segments/seg00040.html">S132</a></td>
-<td>񁋑</td>
-<td></td>
+<td class="signwriting">񁋑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -384,8 +410,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="segments/seg00041.html">S13e</a></td>
-<td>񁝑</td>
-<td></td>
+<td class="signwriting">񁝑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -393,8 +419,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="segments/seg00042.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -402,8 +428,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="segments/seg00043.html">S118</a></td>
-<td>񀤑</td>
-<td></td>
+<td class="signwriting">񀤑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -411,8 +437,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="segments/seg00044.html">S121</a></td>
-<td>񀱱</td>
-<td></td>
+<td class="signwriting">񀱱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -420,8 +446,8 @@
 <td>2_nonspread</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="segments/seg00045.html">None</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -429,8 +455,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="segments/seg00046.html">S116</a></td>
-<td>񀡑</td>
-<td></td>
+<td class="signwriting">񀡑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -438,8 +464,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="segments/seg00047.html">S11a</a></td>
-<td>񀧑</td>
-<td>񀧁</td>
+<td class="signwriting">񀧑</td>
+<td class="signwriting">񀧁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -447,8 +473,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="segments/seg00048.html">S11d</a></td>
-<td>񀫡</td>
-<td></td>
+<td class="signwriting">񀫡</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -456,8 +482,8 @@
 <td>2_nonspread</td>
 <td>2finger_differshape</td>
 <td><a href="segments/seg00049.html">S126</a></td>
-<td>񀹑</td>
-<td></td>
+<td class="signwriting">񀹑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -465,8 +491,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="segments/seg00050.html">S10e</a></td>
-<td>񀕁</td>
-<td></td>
+<td class="signwriting">񀕁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -474,8 +500,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="segments/seg00051.html">S11e</a></td>
-<td>񀭁</td>
-<td></td>
+<td class="signwriting">񀭁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -483,8 +509,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="segments/seg00052.html">S125</a></td>
-<td>񀷱</td>
-<td></td>
+<td class="signwriting">񀷱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -492,8 +518,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="segments/seg00053.html">S19c</a></td>
-<td>񃪑</td>
-<td></td>
+<td class="signwriting">񃪑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -501,8 +527,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="segments/seg00054.html">S1a0</a></td>
-<td>񃰑</td>
-<td></td>
+<td class="signwriting">񃰑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -510,8 +536,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="segments/seg00055.html">S1b0</a></td>
-<td>񄈑</td>
-<td></td>
+<td class="signwriting">񄈑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -519,8 +545,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="segments/seg00056.html">S1b4</a></td>
-<td>񄎑</td>
-<td></td>
+<td class="signwriting">񄎑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -528,8 +554,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="segments/seg00057.html">S1cb</a></td>
-<td>񄰱</td>
-<td></td>
+<td class="signwriting">񄰱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -537,8 +563,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="segments/seg00058.html">S112</a></td>
-<td>񀛑</td>
-<td></td>
+<td class="signwriting">񀛑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -546,8 +572,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="segments/seg00059.html">S123</a></td>
-<td>񀴱</td>
-<td></td>
+<td class="signwriting">񀴱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -555,8 +581,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="segments/seg00060.html">S110</a></td>
-<td>񀘑</td>
-<td></td>
+<td class="signwriting">񀘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -564,8 +590,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="segments/seg00061.html">S121</a></td>
-<td>񀱱</td>
-<td></td>
+<td class="signwriting">񀱱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -573,8 +599,8 @@
 <td>2_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="segments/seg00062.html">S122</a></td>
-<td>񀳑</td>
-<td></td>
+<td class="signwriting">񀳑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -582,8 +608,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="segments/seg00063.html">S126</a></td>
-<td>񀹑</td>
-<td></td>
+<td class="signwriting">񀹑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -591,8 +617,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="segments/seg00064.html">S140</a></td>
-<td>񁠑</td>
-<td></td>
+<td class="signwriting">񁠑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -600,8 +626,8 @@
 <td>2_spread</td>
 <td>2finger_differshape</td>
 <td><a href="segments/seg00065.html">S142</a></td>
-<td>񁣑</td>
-<td></td>
+<td class="signwriting">񁣑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -609,8 +635,8 @@
 <td>3_nonspread</td>
 <td>extended</td>
 <td><a href="segments/seg00066.html">S18e</a></td>
-<td>񃕑</td>
-<td></td>
+<td class="signwriting">񃕑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -618,8 +644,8 @@
 <td>3_nonspread</td>
 <td>flattened</td>
 <td><a href="segments/seg00067.html">None</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -627,8 +653,8 @@
 <td>3_nonspread</td>
 <td>bent</td>
 <td><a href="segments/seg00068.html">None</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -636,8 +662,8 @@
 <td>3_nonspread</td>
 <td>hooked</td>
 <td><a href="segments/seg00069.html">None</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -645,8 +671,8 @@
 <td>3_nonspread</td>
 <td>3finger_differshape</td>
 <td><a href="segments/seg00070.html">None</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -654,8 +680,8 @@
 <td>3_spread</td>
 <td>extended</td>
 <td><a href="segments/seg00071.html">S18f</a></td>
-<td>񃖱</td>
-<td></td>
+<td class="signwriting">񃖱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -663,8 +689,8 @@
 <td>3_spread</td>
 <td>extended</td>
 <td><a href="segments/seg00072.html">S1a4</a></td>
-<td>񃶁</td>
-<td></td>
+<td class="signwriting">񃶁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -672,8 +698,8 @@
 <td>3_spread</td>
 <td>extended</td>
 <td><a href="segments/seg00073.html">S1ab</a></td>
-<td>񄀱</td>
-<td></td>
+<td class="signwriting">񄀱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -681,8 +707,8 @@
 <td>3_spread</td>
 <td>extended</td>
 <td><a href="segments/seg00074.html">S1c4</a></td>
-<td>񄦑</td>
-<td></td>
+<td class="signwriting">񄦑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -690,8 +716,8 @@
 <td>3_spread</td>
 <td>flattened</td>
 <td><a href="segments/seg00075.html">None</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -699,8 +725,8 @@
 <td>3_spread</td>
 <td>bent</td>
 <td><a href="segments/seg00076.html">S190</a></td>
-<td>񃘑</td>
-<td></td>
+<td class="signwriting">񃘑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -708,8 +734,8 @@
 <td>3_spread</td>
 <td>hooked</td>
 <td><a href="segments/seg00077.html">None</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -717,8 +743,8 @@
 <td>3_spread</td>
 <td>3finger_differshape</td>
 <td><a href="segments/seg00078.html">None</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -726,8 +752,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="segments/seg00079.html">S147</a></td>
-<td>񁪱</td>
-<td>񁫁</td>
+<td class="signwriting">񁪱</td>
+<td class="signwriting">񁫁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -735,8 +761,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="segments/seg00080.html">S15a</a></td>
-<td>񂇁</td>
-<td>񂇑</td>
+<td class="signwriting">񂇁</td>
+<td class="signwriting">񂇑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -744,8 +770,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="segments/seg00081.html">S15d</a></td>
-<td>񂋱</td>
-<td>񂋡</td>
+<td class="signwriting">񂋱</td>
+<td class="signwriting">񂋡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -753,8 +779,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="segments/seg00082.html">S14b</a></td>
-<td>񁰱</td>
-<td></td>
+<td class="signwriting">񁰱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -762,8 +788,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="segments/seg00083.html">S180</a></td>
-<td>񃀑</td>
-<td>񃀁</td>
+<td class="signwriting">񃀑</td>
+<td class="signwriting">񃀁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -771,8 +797,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="segments/seg00084.html">S182</a></td>
-<td>񃃑</td>
-<td></td>
+<td class="signwriting">񃃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -780,8 +806,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="segments/seg00085.html">S149</a></td>
-<td>񁭱</td>
-<td></td>
+<td class="signwriting">񁭱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -789,8 +815,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="segments/seg00086.html">S168</a></td>
-<td>񂜑</td>
-<td></td>
+<td class="signwriting">񂜑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -798,8 +824,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="segments/seg00087.html">S16e</a></td>
-<td>񂥑</td>
-<td></td>
+<td class="signwriting">񂥑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -807,8 +833,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="segments/seg00088.html">S170</a></td>
-<td>񂨑</td>
-<td></td>
+<td class="signwriting">񂨑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -816,8 +842,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="segments/seg00089.html">S171</a></td>
-<td>񂩱</td>
-<td></td>
+<td class="signwriting">񂩱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -825,8 +851,8 @@
 <td>4_nonspread</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="segments/seg00090.html">S202</a></td>
-<td>񆃑</td>
-<td></td>
+<td class="signwriting">񆃑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -834,8 +860,8 @@
 <td>4_nonspread</td>
 <td>4finger_differshape</td>
 <td><a href="segments/seg00091.html">S1d7</a></td>
-<td>񅂱</td>
-<td></td>
+<td class="signwriting">񅂱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -843,8 +869,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="segments/seg00092.html">S144</a></td>
-<td>񁦁</td>
-<td>񁦡</td>
+<td class="signwriting">񁦁</td>
+<td class="signwriting">񁦡</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -852,8 +878,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers extended)</td>
 <td><a href="segments/seg00093.html">S14c</a></td>
-<td>񁲁</td>
-<td></td>
+<td class="signwriting">񁲁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -861,8 +887,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="segments/seg00094.html">S146</a></td>
-<td>񁩑</td>
-<td></td>
+<td class="signwriting">񁩑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -870,8 +896,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="segments/seg00095.html">S158</a></td>
-<td>񂄑</td>
-<td></td>
+<td class="signwriting">񂄑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -879,8 +905,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers flattened)</td>
 <td><a href="segments/seg00096.html">S159</a></td>
-<td>񂅱</td>
-<td></td>
+<td class="signwriting">񂅱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -888,8 +914,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="segments/seg00097.html">S145</a></td>
-<td>񁧱</td>
-<td></td>
+<td class="signwriting">񁧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -897,8 +923,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="segments/seg00098.html">S14e</a></td>
-<td>񁵑</td>
-<td></td>
+<td class="signwriting">񁵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -906,8 +932,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers bent)</td>
 <td><a href="segments/seg00099.html">S150</a></td>
-<td>񁸑</td>
-<td></td>
+<td class="signwriting">񁸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -915,8 +941,8 @@
 <td>4_spread</td>
 <td>(Selected Fingers Hooked)</td>
 <td><a href="segments/seg00100.html">None</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -924,8 +950,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="segments/seg00101.html">S157</a></td>
-<td>񂂱</td>
-<td></td>
+<td class="signwriting">񂂱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -933,8 +959,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="segments/seg00102.html">S1a7</a></td>
-<td>񃺱</td>
-<td></td>
+<td class="signwriting">񃺱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -942,8 +968,8 @@
 <td>4_spread</td>
 <td>4finger_differshape</td>
 <td><a href="segments/seg00103.html">S1c5</a></td>
-<td>񄧱</td>
-<td></td>
+<td class="signwriting">񄧱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -951,8 +977,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="segments/seg00104.html">S199</a></td>
-<td>񃥱</td>
-<td></td>
+<td class="signwriting">񃥱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -960,8 +986,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="segments/seg00105.html">S1e5</a></td>
-<td>񅗱</td>
-<td></td>
+<td class="signwriting">񅗱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -969,8 +995,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="segments/seg00106.html">S1e7</a></td>
-<td>񅚱</td>
-<td></td>
+<td class="signwriting">񅚱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -978,8 +1004,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="segments/seg00107.html">S1eb</a></td>
-<td>񅠱</td>
-<td></td>
+<td class="signwriting">񅠱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -987,8 +1013,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="segments/seg00108.html">S1ed</a></td>
-<td>񅣡</td>
-<td>񅢑</td>
+<td class="signwriting">񅣡</td>
+<td class="signwriting">񅢑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -996,8 +1022,8 @@
 <td>1fin_othersFist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="segments/seg00109.html">S19f</a></td>
-<td>񃮱</td>
-<td></td>
+<td class="signwriting">񃮱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1005,8 +1031,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers straight)</td>
 <td><a href="segments/seg00110.html">S1e4</a></td>
-<td>񅖑</td>
-<td></td>
+<td class="signwriting">񅖑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1014,8 +1040,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="segments/seg00111.html">S1ee</a></td>
-<td>񅥑</td>
-<td></td>
+<td class="signwriting">񅥑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1023,8 +1049,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="segments/seg00112.html">S1f0</a></td>
-<td>񅨑</td>
-<td>񅨁</td>
+<td class="signwriting">񅨑</td>
+<td class="signwriting">񅨁</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1032,8 +1058,8 @@
 <td>1fin_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="segments/seg00113.html">S1f4</a></td>
-<td>񅮁</td>
-<td>񅮑</td>
+<td class="signwriting">񅮁</td>
+<td class="signwriting">񅮑</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1041,8 +1067,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="segments/seg00114.html">S129</a></td>
-<td>񀽱</td>
-<td></td>
+<td class="signwriting">񀽱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1050,8 +1076,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="segments/seg00115.html">S13d</a></td>
-<td>񁛡</td>
-<td>񁛱</td>
+<td class="signwriting">񁛡</td>
+<td class="signwriting">񁛱</td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1059,8 +1085,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="segments/seg00116.html">S13f</a></td>
-<td>񁞱</td>
-<td></td>
+<td class="signwriting">񁞱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1068,8 +1094,8 @@
 <td>2finNonspread_othersFist</td>
 <td>(fingers straight)</td>
 <td><a href="segments/seg00117.html">None</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1077,8 +1103,8 @@
 <td>2finNonspread_othersFist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="segments/seg00118.html">S1a3</a></td>
-<td>񃴱</td>
-<td></td>
+<td class="signwriting">񃴱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1086,8 +1112,8 @@
 <td>2finNonspread_othersFist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="segments/seg00119.html">S1b2</a></td>
-<td>񄋑</td>
-<td></td>
+<td class="signwriting">񄋑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1095,8 +1121,8 @@
 <td>2finNonspread_othersFist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="segments/seg00120.html">S1b3</a></td>
-<td>񄌱</td>
-<td></td>
+<td class="signwriting">񄌱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1104,8 +1130,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="segments/seg00121.html">S128</a></td>
-<td>񀼑</td>
-<td></td>
+<td class="signwriting">񀼑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1113,8 +1139,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers rounded)</td>
 <td><a href="segments/seg00122.html">S12a</a></td>
-<td>񀿑</td>
-<td></td>
+<td class="signwriting">񀿑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1122,8 +1148,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers flattened)</td>
 <td><a href="segments/seg00123.html">S12b</a></td>
-<td>񁀱</td>
-<td></td>
+<td class="signwriting">񁀱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1131,8 +1157,8 @@
 <td>2finSpread_othersFist</td>
 <td>(fingers straight)</td>
 <td><a href="segments/seg00124.html">S127</a></td>
-<td>񀺱</td>
-<td></td>
+<td class="signwriting">񀺱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1140,8 +1166,8 @@
 <td>2finSpread_othersFist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="segments/seg00125.html">None</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1149,8 +1175,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="segments/seg00126.html">S16d</a></td>
-<td>񂣱</td>
-<td></td>
+<td class="signwriting">񂣱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1158,8 +1184,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="segments/seg00127.html">S173</a></td>
-<td>񂬱</td>
-<td></td>
+<td class="signwriting">񂬱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1167,8 +1193,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="segments/seg00128.html">S176</a></td>
-<td>񂱑</td>
-<td></td>
+<td class="signwriting">񂱑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1176,8 +1202,8 @@
 <td>4finNonspread</td>
 <td>(fingers rounded)</td>
 <td><a href="segments/seg00129.html">S177</a></td>
-<td>񂲱</td>
-<td></td>
+<td class="signwriting">񂲱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1185,8 +1211,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="segments/seg00130.html">S17c</a></td>
-<td>񂺑</td>
-<td></td>
+<td class="signwriting">񂺑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1194,8 +1220,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="segments/seg00131.html">S17d</a></td>
-<td>񂻱</td>
-<td></td>
+<td class="signwriting">񂻱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1203,8 +1229,8 @@
 <td>4finNonspread</td>
 <td>(fingers flattened)</td>
 <td><a href="segments/seg00132.html">S185</a></td>
-<td>񃇱</td>
-<td></td>
+<td class="signwriting">񃇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1212,8 +1238,8 @@
 <td>4finNonspread</td>
 <td>(fingers straight)</td>
 <td><a href="segments/seg00133.html">S160</a></td>
-<td>񂐑</td>
-<td></td>
+<td class="signwriting">񂐑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1221,8 +1247,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="segments/seg00134.html">S153</a></td>
-<td>񁼱</td>
-<td></td>
+<td class="signwriting">񁼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1230,8 +1256,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="segments/seg00135.html">S154</a></td>
-<td>񁾑</td>
-<td></td>
+<td class="signwriting">񁾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1239,8 +1265,8 @@
 <td>4finSpread</td>
 <td>(fingers rounded)</td>
 <td><a href="segments/seg00136.html">S155</a></td>
-<td>񁿱</td>
-<td></td>
+<td class="signwriting">񁿱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1248,8 +1274,8 @@
 <td>4finSpread</td>
 <td>(fingers flattened)</td>
 <td><a href="segments/seg00137.html">S155</a></td>
-<td>񁿱</td>
-<td></td>
+<td class="signwriting">񁿱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1257,8 +1283,8 @@
 <td>4finSpread</td>
 <td>(fingers straight)</td>
 <td><a href="segments/seg00138.html">None</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1266,8 +1292,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="segments/seg00139.html">S187</a></td>
-<td>񃊱</td>
-<td></td>
+<td class="signwriting">񃊱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1275,8 +1301,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="segments/seg00140.html">S18b</a></td>
-<td>񃐱</td>
-<td></td>
+<td class="signwriting">񃐱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1284,8 +1310,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="segments/seg00141.html">S1a4</a></td>
-<td>񃶁</td>
-<td></td>
+<td class="signwriting">񃶁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1293,8 +1319,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="segments/seg00142.html">S1a5</a></td>
-<td>񃷱</td>
-<td></td>
+<td class="signwriting">񃷱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1302,8 +1328,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="segments/seg00143.html">S1ba</a></td>
-<td>񄗁</td>
-<td></td>
+<td class="signwriting">񄗁</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1311,8 +1337,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="segments/seg00144.html">S1bb</a></td>
-<td>񄘱</td>
-<td></td>
+<td class="signwriting">񄘱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1320,8 +1346,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="segments/seg00145.html">S1ce</a></td>
-<td>񄵑</td>
-<td></td>
+<td class="signwriting">񄵑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1329,8 +1355,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="segments/seg00146.html">S1d0</a></td>
-<td>񄸑</td>
-<td></td>
+<td class="signwriting">񄸑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1338,8 +1364,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="segments/seg00147.html">S1d5</a></td>
-<td>񄿱</td>
-<td></td>
+<td class="signwriting">񄿱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1347,8 +1373,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="segments/seg00148.html">S1d6</a></td>
-<td>񅁑</td>
-<td></td>
+<td class="signwriting">񅁑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1356,8 +1382,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others spread)</td>
 <td><a href="segments/seg00149.html">Missing</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1365,8 +1391,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="segments/seg00150.html">S18c</a></td>
-<td>񃒑</td>
-<td></td>
+<td class="signwriting">񃒑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1374,8 +1400,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="segments/seg00151.html">S18d</a></td>
-<td>񃓱</td>
-<td></td>
+<td class="signwriting">񃓱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1383,8 +1409,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb rounded,others nonspread)</td>
 <td><a href="segments/seg00152.html">S1da</a></td>
-<td>񅇑</td>
-<td></td>
+<td class="signwriting">񅇑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1392,8 +1418,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="segments/seg00153.html">S1c1</a></td>
-<td>񄡱</td>
-<td></td>
+<td class="signwriting">񄡱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1401,8 +1427,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="segments/seg00154.html">S1c3</a></td>
-<td>񄤱</td>
-<td></td>
+<td class="signwriting">񄤱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1410,8 +1436,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="segments/seg00155.html">S1d1</a></td>
-<td>񄹱</td>
-<td></td>
+<td class="signwriting">񄹱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1419,8 +1445,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="segments/seg00156.html">S1d2</a></td>
-<td>񄻑</td>
-<td></td>
+<td class="signwriting">񄻑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1428,8 +1454,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="segments/seg00157.html">S1d3</a></td>
-<td>񄼱</td>
-<td></td>
+<td class="signwriting">񄼱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1437,8 +1463,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="segments/seg00158.html">S1d4</a></td>
-<td>񄾑</td>
-<td></td>
+<td class="signwriting">񄾑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1446,8 +1472,8 @@
 <td>1fin_othersNonfist</td>
 <td>(thumb flattened)</td>
 <td><a href="segments/seg00159.html">S1d8</a></td>
-<td>񅄑</td>
-<td></td>
+<td class="signwriting">񅄑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1455,8 +1481,8 @@
 <td>1fin_othersNonfist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="segments/seg00160.html">S105</a></td>
-<td>񀇱</td>
-<td></td>
+<td class="signwriting">񀇱</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1464,8 +1490,8 @@
 <td>1fin_othersNonfist</td>
 <td>FlattenedandInFistfingerUp</td>
 <td><a href="segments/seg00161.html">S196</a></td>
-<td>񃡑</td>
-<td></td>
+<td class="signwriting">񃡑</td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1473,8 +1499,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00162.html">S10b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1482,8 +1508,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00163.html">S14a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1491,8 +1517,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00164.html">S14d</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1500,8 +1526,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00165.html">S16f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1509,8 +1535,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00166.html">S17e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1518,8 +1544,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00167.html">S1cd</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1527,8 +1553,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00168.html">S1dd</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1536,8 +1562,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00169.html">S102</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1545,8 +1571,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00170.html">S104</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1554,8 +1580,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00171.html">S107</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1563,8 +1589,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00172.html">S109</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1572,8 +1598,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00173.html">S10d</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1581,8 +1607,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00174.html">S10f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1590,8 +1616,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00175.html">S111</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1599,8 +1625,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00176.html">S113</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1608,8 +1634,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00177.html">S114</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1617,8 +1643,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00178.html">S117</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1626,8 +1652,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00179.html">S11b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1635,8 +1661,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00180.html">S11c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1644,8 +1670,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00181.html">S11f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1653,8 +1679,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00182.html">S120</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1662,8 +1688,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00183.html">S124</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1671,8 +1697,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00184.html">S12c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1680,8 +1706,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00185.html">S12e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1689,8 +1715,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00186.html">S12f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1698,8 +1724,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00187.html">S130</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1707,8 +1733,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00188.html">S131</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1716,8 +1742,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00189.html">S133</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1725,8 +1751,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00190.html">S134</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1734,8 +1760,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00191.html">S135</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1743,8 +1769,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00192.html">S136</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1752,8 +1778,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00193.html">S137</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1761,8 +1787,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00194.html">S138</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1770,8 +1796,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00195.html">S139</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1779,8 +1805,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00196.html">S13a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1788,8 +1814,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00197.html">S13b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1797,8 +1823,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00198.html">S13c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1806,8 +1832,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00199.html">S141</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1815,8 +1841,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00200.html">S143</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1824,8 +1850,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00201.html">S148</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1833,8 +1859,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00202.html">S14f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1842,8 +1868,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00203.html">S151</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1851,8 +1877,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00204.html">S152</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1860,8 +1886,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00205.html">S156</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1869,8 +1895,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00206.html">S15b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1878,8 +1904,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00207.html">S15c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1887,8 +1913,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00208.html">S15e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1896,8 +1922,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00209.html">S15f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1905,8 +1931,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00210.html">S161</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1914,8 +1940,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00211.html">S162</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1923,8 +1949,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00212.html">S163</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1932,8 +1958,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00213.html">S164</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1941,8 +1967,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00214.html">S165</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1950,8 +1976,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00215.html">S166</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1959,8 +1985,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00216.html">S167</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1968,8 +1994,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00217.html">S169</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1977,8 +2003,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00218.html">S16a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1986,8 +2012,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00219.html">S16b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -1995,8 +2021,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00220.html">S16c</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2004,8 +2030,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00221.html">S172</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2013,8 +2039,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00222.html">S174</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2022,8 +2048,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00223.html">S175</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2031,8 +2057,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00224.html">S178</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2040,8 +2066,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00225.html">S179</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2049,8 +2075,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00226.html">S17a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2058,8 +2084,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00227.html">S17b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2067,8 +2093,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00228.html">S17f</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2076,8 +2102,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00229.html">S181</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2085,8 +2111,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00230.html">S183</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2094,8 +2120,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00231.html">S184</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2103,8 +2129,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00232.html">S186</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2112,8 +2138,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00233.html">S188</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2121,8 +2147,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00234.html">S189</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2130,8 +2156,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00235.html">S18a</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2139,8 +2165,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00236.html">S191</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2148,8 +2174,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00237.html">S194</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2157,8 +2183,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00238.html">S195</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2166,8 +2192,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00239.html">S197</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2175,8 +2201,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00240.html">S19b</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2184,8 +2210,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00241.html">S19d</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2193,8 +2219,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00242.html">S19e</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2202,8 +2228,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00243.html">S1a1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2211,8 +2237,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00244.html">S1a2</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2220,8 +2246,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00245.html">S1a6</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2229,8 +2255,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00246.html">S1a8</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2238,8 +2264,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00247.html">S1a9</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2247,8 +2273,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00248.html">S1aa</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2256,8 +2282,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00249.html">S1ac</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2265,8 +2291,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00250.html">S1af</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2274,8 +2300,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00251.html">S1b1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2283,8 +2309,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00252.html">S1b6</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2292,8 +2318,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00253.html">S1b7</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2301,8 +2327,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00254.html">S1b8</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2310,8 +2336,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00255.html">S1b9</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2319,8 +2345,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00256.html">S1bc</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2328,8 +2354,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00257.html">S1bd</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2337,8 +2363,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00258.html">S1be</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2346,8 +2372,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00259.html">S1bf</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2355,8 +2381,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00260.html">S1c0</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2364,8 +2390,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00261.html">S1c2</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2373,8 +2399,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00262.html">S1c7</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2382,8 +2408,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00263.html">S1c8</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2391,8 +2417,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00264.html">S1c9</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2400,8 +2426,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00265.html">S1ca</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2409,8 +2435,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00266.html">S1cc</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2418,8 +2444,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00267.html">S1cf</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2427,8 +2453,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00268.html">S1d9</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2436,8 +2462,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00269.html">S1db</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2445,8 +2471,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00270.html">S1e3</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2454,8 +2480,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00271.html">S1e6</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2463,8 +2489,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00272.html">S1e8</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2472,8 +2498,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00273.html">S1ec</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2481,8 +2507,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00274.html">S1ef</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2490,8 +2516,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00275.html">S1f1</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2499,8 +2525,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00276.html">S1f6</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2508,8 +2534,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00277.html">S1fa</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <td>handshape</td>
@@ -2517,8 +2543,8 @@
 <td></td>
 <td></td>
 <td><a href="segments/seg00278.html">S1fe</a></td>
-<td></td>
-<td></td>
+<td class="signwriting"></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 </body>

--- a/segments/seg00001.html
+++ b/segments/seg00001.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1f5</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1f5</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񅯣</td>
+<td class="signwriting">񅯣</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td>񅯡</td>
+<td class="signwriting">񅯡</td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00002.html
+++ b/segments/seg00002.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1f7</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1f7</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񅲱</td>
+<td class="signwriting">񅲱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td>񅳁</td>
+<td class="signwriting">񅳁</td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00003.html
+++ b/segments/seg00003.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1f8</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1f8</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񅴑</td>
+<td class="signwriting">񅴑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00004.html
+++ b/segments/seg00004.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S203</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S203</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񆄱</td>
+<td class="signwriting">񆄱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td>񆅁</td>
+<td class="signwriting">񆅁</td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00005.html
+++ b/segments/seg00005.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1f9</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1f9</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񅵱</td>
+<td class="signwriting">񅵱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00006.html
+++ b/segments/seg00006.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1fb</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1fb</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񅸱</td>
+<td class="signwriting">񅸱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00007.html
+++ b/segments/seg00007.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1fc</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1fc</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񅺡</td>
+<td class="signwriting">񅺡</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td>񅺑</td>
+<td class="signwriting">񅺑</td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00008.html
+++ b/segments/seg00008.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1fd</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1fd</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񅼁</td>
+<td class="signwriting">񅼁</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td>񅻱</td>
+<td class="signwriting">񅻱</td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00009.html
+++ b/segments/seg00009.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1ff</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1ff</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񅾱</td>
+<td class="signwriting">񅾱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00010.html
+++ b/segments/seg00010.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S200</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S200</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񆀑</td>
+<td class="signwriting">񆀑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00011.html
+++ b/segments/seg00011.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S201</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S201</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񆁱</td>
+<td class="signwriting">񆁱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00012.html
+++ b/segments/seg00012.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S100</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S100</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񀀁</td>
+<td class="signwriting">񀀁</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00013.html
+++ b/segments/seg00013.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S101</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S101</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񀁱</td>
+<td class="signwriting">񀁱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00014.html
+++ b/segments/seg00014.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S103</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S103</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񀄱</td>
+<td class="signwriting">񀄱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00015.html
+++ b/segments/seg00015.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S108</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S108</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񀌑</td>
+<td class="signwriting">񀌑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00016.html
+++ b/segments/seg00016.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S192</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S192</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񃛑</td>
+<td class="signwriting">񃛑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td>񃛁</td>
+<td class="signwriting">񃛁</td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00017.html
+++ b/segments/seg00017.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S193</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S193</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񃜱</td>
+<td class="signwriting">񃜱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00018.html
+++ b/segments/seg00018.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S19a</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S19a</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񃧑</td>
+<td class="signwriting">񃧑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td>񃧁</td>
+<td class="signwriting">񃧁</td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00019.html
+++ b/segments/seg00019.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1ae</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1ae</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񄅑</td>
+<td class="signwriting">񄅑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00020.html
+++ b/segments/seg00020.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1c6</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1c6</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񄩁</td>
+<td class="signwriting">񄩁</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td>񄩑</td>
+<td class="signwriting">񄩑</td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00021.html
+++ b/segments/seg00021.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1dc</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1dc</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񅊑</td>
+<td class="signwriting">񅊑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td>񅊡</td>
+<td class="signwriting">񅊡</td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00022.html
+++ b/segments/seg00022.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1de</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1de</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񅍑</td>
+<td class="signwriting">񅍑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00023.html
+++ b/segments/seg00023.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1df</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1df</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񅎱</td>
+<td class="signwriting">񅎱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00024.html
+++ b/segments/seg00024.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1e0</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1e0</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񅐁</td>
+<td class="signwriting">񅐁</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td>񅐑</td>
+<td class="signwriting">񅐑</td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00025.html
+++ b/segments/seg00025.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S10c</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S10c</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񀒑</td>
+<td class="signwriting">񀒑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00026.html
+++ b/segments/seg00026.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1f2</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1f2</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񅫁</td>
+<td class="signwriting">񅫁</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00027.html
+++ b/segments/seg00027.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1f3</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1f3</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񅬱</td>
+<td class="signwriting">񅬱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00028.html
+++ b/segments/seg00028.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S106</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S106</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񀉑</td>
+<td class="signwriting">񀉑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00029.html
+++ b/segments/seg00029.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S10a</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S10a</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񀏑</td>
+<td class="signwriting">񀏑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00030.html
+++ b/segments/seg00030.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S198</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S198</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񃤑</td>
+<td class="signwriting">񃤑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00031.html
+++ b/segments/seg00031.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1e1</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1e1</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񅑱</td>
+<td class="signwriting">񅑱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td>񅑡</td>
+<td class="signwriting">񅑡</td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00032.html
+++ b/segments/seg00032.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1e2</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1e2</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񅓁</td>
+<td class="signwriting">񅓁</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00033.html
+++ b/segments/seg00033.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape Missing</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape Missing</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00034.html
+++ b/segments/seg00034.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape Missing</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape Missing</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00035.html
+++ b/segments/seg00035.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1ea</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1ea</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񅟑</td>
+<td class="signwriting">񅟑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td>񅟁</td>
+<td class="signwriting">񅟁</td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00036.html
+++ b/segments/seg00036.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S115</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S115</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񀟱</td>
+<td class="signwriting">񀟱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00037.html
+++ b/segments/seg00037.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S12d</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S12d</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񁃡</td>
+<td class="signwriting">񁃡</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td>񁃱</td>
+<td class="signwriting">񁃱</td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00038.html
+++ b/segments/seg00038.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1b5</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1b5</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񄏱</td>
+<td class="signwriting">񄏱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00039.html
+++ b/segments/seg00039.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S119</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S119</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񀥱</td>
+<td class="signwriting">񀥱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00040.html
+++ b/segments/seg00040.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S132</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S132</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񁋑</td>
+<td class="signwriting">񁋑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00041.html
+++ b/segments/seg00041.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S13e</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S13e</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񁝑</td>
+<td class="signwriting">񁝑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00042.html
+++ b/segments/seg00042.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S110</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S110</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񀘑</td>
+<td class="signwriting">񀘑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00043.html
+++ b/segments/seg00043.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S118</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S118</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񀤑</td>
+<td class="signwriting">񀤑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00044.html
+++ b/segments/seg00044.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S121</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S121</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񀱱</td>
+<td class="signwriting">񀱱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00045.html
+++ b/segments/seg00045.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape None</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape None</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00046.html
+++ b/segments/seg00046.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S116</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S116</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񀡑</td>
+<td class="signwriting">񀡑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00047.html
+++ b/segments/seg00047.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S11a</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S11a</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񀧑</td>
+<td class="signwriting">񀧑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td>񀧁</td>
+<td class="signwriting">񀧁</td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00048.html
+++ b/segments/seg00048.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S11d</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S11d</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񀫡</td>
+<td class="signwriting">񀫡</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00049.html
+++ b/segments/seg00049.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S126</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S126</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񀹑</td>
+<td class="signwriting">񀹑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00050.html
+++ b/segments/seg00050.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S10e</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S10e</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񀕁</td>
+<td class="signwriting">񀕁</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00051.html
+++ b/segments/seg00051.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S11e</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S11e</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񀭁</td>
+<td class="signwriting">񀭁</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00052.html
+++ b/segments/seg00052.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S125</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S125</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񀷱</td>
+<td class="signwriting">񀷱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00053.html
+++ b/segments/seg00053.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S19c</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S19c</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񃪑</td>
+<td class="signwriting">񃪑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00054.html
+++ b/segments/seg00054.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1a0</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1a0</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񃰑</td>
+<td class="signwriting">񃰑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00055.html
+++ b/segments/seg00055.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1b0</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1b0</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񄈑</td>
+<td class="signwriting">񄈑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00056.html
+++ b/segments/seg00056.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1b4</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1b4</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񄎑</td>
+<td class="signwriting">񄎑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00057.html
+++ b/segments/seg00057.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1cb</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1cb</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񄰱</td>
+<td class="signwriting">񄰱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00058.html
+++ b/segments/seg00058.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S112</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S112</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񀛑</td>
+<td class="signwriting">񀛑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00059.html
+++ b/segments/seg00059.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S123</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S123</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񀴱</td>
+<td class="signwriting">񀴱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00060.html
+++ b/segments/seg00060.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S110</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S110</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񀘑</td>
+<td class="signwriting">񀘑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00061.html
+++ b/segments/seg00061.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S121</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S121</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񀱱</td>
+<td class="signwriting">񀱱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00062.html
+++ b/segments/seg00062.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S122</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S122</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񀳑</td>
+<td class="signwriting">񀳑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00063.html
+++ b/segments/seg00063.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S126</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S126</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񀹑</td>
+<td class="signwriting">񀹑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00064.html
+++ b/segments/seg00064.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S140</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S140</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񁠑</td>
+<td class="signwriting">񁠑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00065.html
+++ b/segments/seg00065.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S142</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S142</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񁣑</td>
+<td class="signwriting">񁣑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00066.html
+++ b/segments/seg00066.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S18e</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S18e</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񃕑</td>
+<td class="signwriting">񃕑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00067.html
+++ b/segments/seg00067.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape None</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape None</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00068.html
+++ b/segments/seg00068.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape None</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape None</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00069.html
+++ b/segments/seg00069.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape None</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape None</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00070.html
+++ b/segments/seg00070.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape None</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape None</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00071.html
+++ b/segments/seg00071.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S18f</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S18f</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񃖱</td>
+<td class="signwriting">񃖱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00072.html
+++ b/segments/seg00072.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1a4</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1a4</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񃶁</td>
+<td class="signwriting">񃶁</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00073.html
+++ b/segments/seg00073.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1ab</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1ab</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񄀱</td>
+<td class="signwriting">񄀱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00074.html
+++ b/segments/seg00074.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1c4</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1c4</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񄦑</td>
+<td class="signwriting">񄦑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00075.html
+++ b/segments/seg00075.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape None</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape None</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00076.html
+++ b/segments/seg00076.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S190</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S190</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񃘑</td>
+<td class="signwriting">񃘑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00077.html
+++ b/segments/seg00077.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape None</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape None</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00078.html
+++ b/segments/seg00078.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape None</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape None</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00079.html
+++ b/segments/seg00079.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S147</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S147</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񁪱</td>
+<td class="signwriting">񁪱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td>񁫁</td>
+<td class="signwriting">񁫁</td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00080.html
+++ b/segments/seg00080.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S15a</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S15a</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񂇁</td>
+<td class="signwriting">񂇁</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td>񂇑</td>
+<td class="signwriting">񂇑</td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00081.html
+++ b/segments/seg00081.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S15d</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S15d</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񂋱</td>
+<td class="signwriting">񂋱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td>񂋡</td>
+<td class="signwriting">񂋡</td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00082.html
+++ b/segments/seg00082.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S14b</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S14b</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񁰱</td>
+<td class="signwriting">񁰱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00083.html
+++ b/segments/seg00083.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S180</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S180</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񃀑</td>
+<td class="signwriting">񃀑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td>񃀁</td>
+<td class="signwriting">񃀁</td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00084.html
+++ b/segments/seg00084.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S182</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S182</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񃃑</td>
+<td class="signwriting">񃃑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00085.html
+++ b/segments/seg00085.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S149</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S149</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񁭱</td>
+<td class="signwriting">񁭱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00086.html
+++ b/segments/seg00086.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S168</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S168</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񂜑</td>
+<td class="signwriting">񂜑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00087.html
+++ b/segments/seg00087.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S16e</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S16e</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񂥑</td>
+<td class="signwriting">񂥑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00088.html
+++ b/segments/seg00088.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S170</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S170</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񂨑</td>
+<td class="signwriting">񂨑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00089.html
+++ b/segments/seg00089.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S171</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S171</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񂩱</td>
+<td class="signwriting">񂩱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00090.html
+++ b/segments/seg00090.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S202</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S202</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񆃑</td>
+<td class="signwriting">񆃑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00091.html
+++ b/segments/seg00091.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1d7</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1d7</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񅂱</td>
+<td class="signwriting">񅂱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00092.html
+++ b/segments/seg00092.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S144</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S144</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񁦁</td>
+<td class="signwriting">񁦁</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td>񁦡</td>
+<td class="signwriting">񁦡</td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00093.html
+++ b/segments/seg00093.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S14c</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S14c</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񁲁</td>
+<td class="signwriting">񁲁</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00094.html
+++ b/segments/seg00094.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S146</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S146</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񁩑</td>
+<td class="signwriting">񁩑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00095.html
+++ b/segments/seg00095.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S158</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S158</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񂄑</td>
+<td class="signwriting">񂄑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00096.html
+++ b/segments/seg00096.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S159</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S159</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񂅱</td>
+<td class="signwriting">񂅱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00097.html
+++ b/segments/seg00097.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S145</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S145</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񁧱</td>
+<td class="signwriting">񁧱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00098.html
+++ b/segments/seg00098.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S14e</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S14e</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񁵑</td>
+<td class="signwriting">񁵑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00099.html
+++ b/segments/seg00099.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S150</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S150</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񁸑</td>
+<td class="signwriting">񁸑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00100.html
+++ b/segments/seg00100.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape None</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape None</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00101.html
+++ b/segments/seg00101.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S157</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S157</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񂂱</td>
+<td class="signwriting">񂂱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00102.html
+++ b/segments/seg00102.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1a7</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1a7</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񃺱</td>
+<td class="signwriting">񃺱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00103.html
+++ b/segments/seg00103.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1c5</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1c5</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񄧱</td>
+<td class="signwriting">񄧱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00104.html
+++ b/segments/seg00104.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S199</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S199</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񃥱</td>
+<td class="signwriting">񃥱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00105.html
+++ b/segments/seg00105.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1e5</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1e5</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񅗱</td>
+<td class="signwriting">񅗱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00106.html
+++ b/segments/seg00106.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1e7</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1e7</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񅚱</td>
+<td class="signwriting">񅚱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00107.html
+++ b/segments/seg00107.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1eb</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1eb</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񅠱</td>
+<td class="signwriting">񅠱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00108.html
+++ b/segments/seg00108.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1ed</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1ed</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񅣡</td>
+<td class="signwriting">񅣡</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td>񅢑</td>
+<td class="signwriting">񅢑</td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00109.html
+++ b/segments/seg00109.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S19f</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S19f</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񃮱</td>
+<td class="signwriting">񃮱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00110.html
+++ b/segments/seg00110.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1e4</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1e4</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񅖑</td>
+<td class="signwriting">񅖑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00111.html
+++ b/segments/seg00111.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1ee</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1ee</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񅥑</td>
+<td class="signwriting">񅥑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00112.html
+++ b/segments/seg00112.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1f0</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1f0</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񅨑</td>
+<td class="signwriting">񅨑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td>񅨁</td>
+<td class="signwriting">񅨁</td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00113.html
+++ b/segments/seg00113.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1f4</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1f4</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񅮁</td>
+<td class="signwriting">񅮁</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td>񅮑</td>
+<td class="signwriting">񅮑</td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00114.html
+++ b/segments/seg00114.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S129</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S129</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񀽱</td>
+<td class="signwriting">񀽱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00115.html
+++ b/segments/seg00115.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S13d</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S13d</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񁛡</td>
+<td class="signwriting">񁛡</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td>񁛱</td>
+<td class="signwriting">񁛱</td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00116.html
+++ b/segments/seg00116.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S13f</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S13f</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񁞱</td>
+<td class="signwriting">񁞱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00117.html
+++ b/segments/seg00117.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape None</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape None</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00118.html
+++ b/segments/seg00118.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1a3</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1a3</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񃴱</td>
+<td class="signwriting">񃴱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00119.html
+++ b/segments/seg00119.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1b2</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1b2</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񄋑</td>
+<td class="signwriting">񄋑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00120.html
+++ b/segments/seg00120.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1b3</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1b3</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񄌱</td>
+<td class="signwriting">񄌱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00121.html
+++ b/segments/seg00121.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S128</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S128</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񀼑</td>
+<td class="signwriting">񀼑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00122.html
+++ b/segments/seg00122.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S12a</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S12a</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񀿑</td>
+<td class="signwriting">񀿑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00123.html
+++ b/segments/seg00123.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S12b</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S12b</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񁀱</td>
+<td class="signwriting">񁀱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00124.html
+++ b/segments/seg00124.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S127</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S127</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񀺱</td>
+<td class="signwriting">񀺱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00125.html
+++ b/segments/seg00125.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape None</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape None</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00126.html
+++ b/segments/seg00126.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S16d</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S16d</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񂣱</td>
+<td class="signwriting">񂣱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00127.html
+++ b/segments/seg00127.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S173</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S173</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񂬱</td>
+<td class="signwriting">񂬱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00128.html
+++ b/segments/seg00128.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S176</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S176</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񂱑</td>
+<td class="signwriting">񂱑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00129.html
+++ b/segments/seg00129.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S177</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S177</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񂲱</td>
+<td class="signwriting">񂲱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00130.html
+++ b/segments/seg00130.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S17c</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S17c</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񂺑</td>
+<td class="signwriting">񂺑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00131.html
+++ b/segments/seg00131.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S17d</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S17d</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񂻱</td>
+<td class="signwriting">񂻱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00132.html
+++ b/segments/seg00132.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S185</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S185</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񃇱</td>
+<td class="signwriting">񃇱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00133.html
+++ b/segments/seg00133.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S160</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S160</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񂐑</td>
+<td class="signwriting">񂐑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00134.html
+++ b/segments/seg00134.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S153</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S153</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񁼱</td>
+<td class="signwriting">񁼱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00135.html
+++ b/segments/seg00135.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S154</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S154</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񁾑</td>
+<td class="signwriting">񁾑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00136.html
+++ b/segments/seg00136.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S155</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S155</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񁿱</td>
+<td class="signwriting">񁿱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00137.html
+++ b/segments/seg00137.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S155</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S155</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񁿱</td>
+<td class="signwriting">񁿱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00138.html
+++ b/segments/seg00138.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape None</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape None</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00139.html
+++ b/segments/seg00139.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S187</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S187</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񃊱</td>
+<td class="signwriting">񃊱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00140.html
+++ b/segments/seg00140.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S18b</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S18b</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񃐱</td>
+<td class="signwriting">񃐱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00141.html
+++ b/segments/seg00141.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1a4</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1a4</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񃶁</td>
+<td class="signwriting">񃶁</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00142.html
+++ b/segments/seg00142.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1a5</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1a5</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񃷱</td>
+<td class="signwriting">񃷱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00143.html
+++ b/segments/seg00143.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1ba</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1ba</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񄗁</td>
+<td class="signwriting">񄗁</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00144.html
+++ b/segments/seg00144.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1bb</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1bb</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񄘱</td>
+<td class="signwriting">񄘱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00145.html
+++ b/segments/seg00145.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1ce</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1ce</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񄵑</td>
+<td class="signwriting">񄵑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00146.html
+++ b/segments/seg00146.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1d0</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1d0</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񄸑</td>
+<td class="signwriting">񄸑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00147.html
+++ b/segments/seg00147.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1d5</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1d5</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񄿱</td>
+<td class="signwriting">񄿱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00148.html
+++ b/segments/seg00148.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1d6</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1d6</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񅁑</td>
+<td class="signwriting">񅁑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00149.html
+++ b/segments/seg00149.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape Missing</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape Missing</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00150.html
+++ b/segments/seg00150.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S18c</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S18c</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񃒑</td>
+<td class="signwriting">񃒑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00151.html
+++ b/segments/seg00151.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S18d</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S18d</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񃓱</td>
+<td class="signwriting">񃓱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00152.html
+++ b/segments/seg00152.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1da</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1da</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񅇑</td>
+<td class="signwriting">񅇑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00153.html
+++ b/segments/seg00153.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1c1</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1c1</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񄡱</td>
+<td class="signwriting">񄡱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00154.html
+++ b/segments/seg00154.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1c3</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1c3</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񄤱</td>
+<td class="signwriting">񄤱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00155.html
+++ b/segments/seg00155.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1d1</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1d1</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񄹱</td>
+<td class="signwriting">񄹱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00156.html
+++ b/segments/seg00156.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1d2</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1d2</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񄻑</td>
+<td class="signwriting">񄻑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00157.html
+++ b/segments/seg00157.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1d3</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1d3</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񄼱</td>
+<td class="signwriting">񄼱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00158.html
+++ b/segments/seg00158.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1d4</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1d4</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񄾑</td>
+<td class="signwriting">񄾑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00159.html
+++ b/segments/seg00159.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1d8</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1d8</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񅄑</td>
+<td class="signwriting">񅄑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00160.html
+++ b/segments/seg00160.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S105</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S105</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񀇱</td>
+<td class="signwriting">񀇱</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00161.html
+++ b/segments/seg00161.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S196</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S196</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td>񃡑</td>
+<td class="signwriting">񃡑</td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00162.html
+++ b/segments/seg00162.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S10b</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S10b</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00163.html
+++ b/segments/seg00163.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S14a</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S14a</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00164.html
+++ b/segments/seg00164.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S14d</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S14d</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00165.html
+++ b/segments/seg00165.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S16f</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S16f</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00166.html
+++ b/segments/seg00166.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S17e</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S17e</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00167.html
+++ b/segments/seg00167.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1cd</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1cd</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00168.html
+++ b/segments/seg00168.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1dd</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1dd</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00169.html
+++ b/segments/seg00169.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S102</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S102</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00170.html
+++ b/segments/seg00170.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S104</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S104</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00171.html
+++ b/segments/seg00171.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S107</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S107</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00172.html
+++ b/segments/seg00172.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S109</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S109</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00173.html
+++ b/segments/seg00173.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S10d</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S10d</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00174.html
+++ b/segments/seg00174.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S10f</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S10f</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00175.html
+++ b/segments/seg00175.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S111</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S111</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00176.html
+++ b/segments/seg00176.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S113</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S113</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00177.html
+++ b/segments/seg00177.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S114</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S114</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00178.html
+++ b/segments/seg00178.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S117</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S117</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00179.html
+++ b/segments/seg00179.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S11b</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S11b</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00180.html
+++ b/segments/seg00180.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S11c</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S11c</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00181.html
+++ b/segments/seg00181.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S11f</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S11f</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00182.html
+++ b/segments/seg00182.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S120</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S120</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00183.html
+++ b/segments/seg00183.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S124</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S124</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00184.html
+++ b/segments/seg00184.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S12c</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S12c</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00185.html
+++ b/segments/seg00185.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S12e</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S12e</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00186.html
+++ b/segments/seg00186.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S12f</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S12f</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00187.html
+++ b/segments/seg00187.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S130</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S130</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00188.html
+++ b/segments/seg00188.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S131</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S131</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00189.html
+++ b/segments/seg00189.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S133</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S133</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00190.html
+++ b/segments/seg00190.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S134</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S134</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00191.html
+++ b/segments/seg00191.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S135</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S135</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00192.html
+++ b/segments/seg00192.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S136</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S136</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00193.html
+++ b/segments/seg00193.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S137</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S137</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00194.html
+++ b/segments/seg00194.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S138</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S138</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00195.html
+++ b/segments/seg00195.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S139</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S139</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00196.html
+++ b/segments/seg00196.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S13a</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S13a</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00197.html
+++ b/segments/seg00197.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S13b</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S13b</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00198.html
+++ b/segments/seg00198.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S13c</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S13c</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00199.html
+++ b/segments/seg00199.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S141</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S141</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00200.html
+++ b/segments/seg00200.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S143</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S143</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00201.html
+++ b/segments/seg00201.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S148</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S148</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00202.html
+++ b/segments/seg00202.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S14f</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S14f</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00203.html
+++ b/segments/seg00203.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S151</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S151</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00204.html
+++ b/segments/seg00204.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S152</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S152</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00205.html
+++ b/segments/seg00205.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S156</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S156</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00206.html
+++ b/segments/seg00206.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S15b</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S15b</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00207.html
+++ b/segments/seg00207.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S15c</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S15c</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00208.html
+++ b/segments/seg00208.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S15e</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S15e</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00209.html
+++ b/segments/seg00209.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S15f</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S15f</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00210.html
+++ b/segments/seg00210.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S161</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S161</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00211.html
+++ b/segments/seg00211.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S162</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S162</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00212.html
+++ b/segments/seg00212.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S163</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S163</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00213.html
+++ b/segments/seg00213.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S164</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S164</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00214.html
+++ b/segments/seg00214.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S165</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S165</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00215.html
+++ b/segments/seg00215.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S166</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S166</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00216.html
+++ b/segments/seg00216.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S167</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S167</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00217.html
+++ b/segments/seg00217.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S169</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S169</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00218.html
+++ b/segments/seg00218.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S16a</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S16a</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00219.html
+++ b/segments/seg00219.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S16b</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S16b</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00220.html
+++ b/segments/seg00220.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S16c</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S16c</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00221.html
+++ b/segments/seg00221.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S172</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S172</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00222.html
+++ b/segments/seg00222.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S174</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S174</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00223.html
+++ b/segments/seg00223.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S175</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S175</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00224.html
+++ b/segments/seg00224.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S178</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S178</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00225.html
+++ b/segments/seg00225.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S179</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S179</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00226.html
+++ b/segments/seg00226.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S17a</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S17a</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00227.html
+++ b/segments/seg00227.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S17b</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S17b</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00228.html
+++ b/segments/seg00228.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S17f</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S17f</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00229.html
+++ b/segments/seg00229.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S181</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S181</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00230.html
+++ b/segments/seg00230.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S183</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S183</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00231.html
+++ b/segments/seg00231.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S184</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S184</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00232.html
+++ b/segments/seg00232.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S186</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S186</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00233.html
+++ b/segments/seg00233.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S188</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S188</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00234.html
+++ b/segments/seg00234.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S189</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S189</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00235.html
+++ b/segments/seg00235.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S18a</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S18a</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00236.html
+++ b/segments/seg00236.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S191</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S191</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00237.html
+++ b/segments/seg00237.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S194</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S194</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00238.html
+++ b/segments/seg00238.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S195</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S195</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00239.html
+++ b/segments/seg00239.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S197</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S197</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00240.html
+++ b/segments/seg00240.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S19b</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S19b</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00241.html
+++ b/segments/seg00241.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S19d</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S19d</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00242.html
+++ b/segments/seg00242.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S19e</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S19e</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00243.html
+++ b/segments/seg00243.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1a1</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1a1</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00244.html
+++ b/segments/seg00244.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1a2</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1a2</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00245.html
+++ b/segments/seg00245.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1a6</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1a6</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00246.html
+++ b/segments/seg00246.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1a8</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1a8</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00247.html
+++ b/segments/seg00247.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1a9</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1a9</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00248.html
+++ b/segments/seg00248.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1aa</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1aa</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00249.html
+++ b/segments/seg00249.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1ac</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1ac</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00250.html
+++ b/segments/seg00250.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1af</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1af</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00251.html
+++ b/segments/seg00251.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1b1</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1b1</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00252.html
+++ b/segments/seg00252.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1b6</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1b6</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00253.html
+++ b/segments/seg00253.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1b7</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1b7</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00254.html
+++ b/segments/seg00254.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1b8</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1b8</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00255.html
+++ b/segments/seg00255.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1b9</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1b9</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00256.html
+++ b/segments/seg00256.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1bc</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1bc</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00257.html
+++ b/segments/seg00257.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1bd</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1bd</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00258.html
+++ b/segments/seg00258.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1be</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1be</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00259.html
+++ b/segments/seg00259.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1bf</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1bf</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00260.html
+++ b/segments/seg00260.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1c0</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1c0</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00261.html
+++ b/segments/seg00261.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1c2</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1c2</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00262.html
+++ b/segments/seg00262.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1c7</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1c7</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00263.html
+++ b/segments/seg00263.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1c8</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1c8</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00264.html
+++ b/segments/seg00264.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1c9</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1c9</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00265.html
+++ b/segments/seg00265.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1ca</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1ca</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00266.html
+++ b/segments/seg00266.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1cc</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1cc</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00267.html
+++ b/segments/seg00267.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1cf</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1cf</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00268.html
+++ b/segments/seg00268.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1d9</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1d9</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00269.html
+++ b/segments/seg00269.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1db</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1db</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00270.html
+++ b/segments/seg00270.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1e3</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1e3</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00271.html
+++ b/segments/seg00271.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1e6</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1e6</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00272.html
+++ b/segments/seg00272.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1e8</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1e8</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00273.html
+++ b/segments/seg00273.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1ec</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1ec</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00274.html
+++ b/segments/seg00274.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1ef</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1ef</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00275.html
+++ b/segments/seg00275.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1f1</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1f1</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00276.html
+++ b/segments/seg00276.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1f6</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1f6</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00277.html
+++ b/segments/seg00277.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1fa</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1fa</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 

--- a/segments/seg00278.html
+++ b/segments/seg00278.html
@@ -4,6 +4,32 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handshape S1fe</title>
+  
+<style>
+@font-face {
+  font-family: "SuttonSignWritingLine";
+  src:
+    local('SuttonSignWritingLine'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingFill";
+  src:
+    local('SuttonSignWritingFill'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
+}
+@font-face {
+  font-family: "SuttonSignWritingOneD";
+  src:
+    local('SuttonSignWritingOneD'),
+    url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
+}
+.signwriting {
+  font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
+  font-size: 2em;
+}
+</style>
+
 </head>
 <body>
   <h1>Handshape S1fe</h1>
@@ -37,11 +63,11 @@
 </tr>
 <tr>
 <th>Signwriting 1</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 <tr>
 <th>Signwriting 2</th>
-<td></td>
+<td class="signwriting"></td>
 </tr>
 </tbody></table>
 


### PR DESCRIPTION
This PR reimplements the SignWriting font-loading changes originally proposed in #16 on top of the current main branch.

Previously, SignWriting symbols did not always display on the HTML pages because the pages relied on the user's browser already having access to Sutton SignWriting fonts.

This PR:
1) Adds SignWriting font-loading CSS to generator.py, sbuilder.py, and ibuilder.py.
2) Applies the SignWriting font to SignWriting cells.
3) Regenerates the main segment/inventory HTML pages, individual segment pages, and individual inventory pages.

Supersedes #16.
Closes #13.